### PR TITLE
Feature/3 security base

### DIFF
--- a/src/main/java/com/roommate/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/roommate/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.roommate.common.jwt;
+
+import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.member.entity.MemberEntity;
+import com.roommate.domain.member.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 요청이 들어올때 마다 실행되는 메서드
+     * AUTHORIZATION_HEADER 헤더에서 JWT 추출
+     * 토큰이 유효한지 검증
+     * 유효하면 스프링 시큐리티에 등록
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        //Http 헤더에서 'Authorization' 가져옴
+        String bearerToken = request.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+        if (bearerToken != null && bearerToken.startsWith(JwtUtil.BEARER_PREFIX)) {
+            try {
+                String token = jwtUtil.substringToken(bearerToken);
+                if (jwtUtil.validateToken(token)) {
+                    Claims userInfo = jwtUtil.getUserInfoFromToken(token);
+                    Long userId = Long.parseLong(userInfo.getSubject());
+                    setAuthentication(userId);
+                }
+            } catch (Exception e) {
+                log.error("JWT인증 처리 중 예외 발생 : " + e.getMessage());
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * JWT가 유효하면 스프링  시큐리티에 등록하는 메서드
+     */
+    private void setAuthentication(Long userId) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        MemberEntity memberEntity = memberRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("해당 id값으로 사용자를 찾을 수 없습니다. id=" + userId));
+        UserDetailsImpl userDetails = new UserDetailsImpl(memberEntity);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/src/main/java/com/roommate/common/security/SecurityConfig.java
+++ b/src/main/java/com/roommate/common/security/SecurityConfig.java
@@ -1,4 +1,54 @@
 package com.roommate.common.security;
 
-public class SecurityConfig {
+import com.roommate.common.jwt.JwtAuthenticationFilter;
+import com.roommate.common.jwt.JwtUtil;
+import com.roommate.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtUtil jwtUtil;
+    private final MemberRepository memberRepository;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil, memberRepository);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.authorizeRequests()
+                .antMatchers("/api/auth/signup", "/api/auth/login").permitAll()
+                .antMatchers("/", "/index", "/resources/**", "/room").permitAll()
+                .antMatchers("/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated();
+        http.formLogin().disable().httpBasic().disable();
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
 }

--- a/src/main/java/com/roommate/common/security/UserDetailsImpl.java
+++ b/src/main/java/com/roommate/common/security/UserDetailsImpl.java
@@ -1,0 +1,53 @@
+package com.roommate.common.security;
+
+import com.roommate.domain.member.entity.MemberEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final MemberEntity memberEntity;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(memberEntity.getRole().getAuthority()));
+    }
+
+    @Override
+    public String getPassword() {
+        return memberEntity.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return memberEntity.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/roommate/common/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/roommate/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,23 @@
+package com.roommate.common.security;
+
+import com.roommate.domain.member.entity.MemberEntity;
+import com.roommate.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        MemberEntity memberEntity = memberRepository.findByEmail(email).orElseThrow(()-> new UsernameNotFoundException("해당 이메일 사용자가 없습니다. email="+email));
+        return new UserDetailsImpl(memberEntity);
+    }
+}

--- a/src/main/java/com/roommate/domain/member/entity/MemberDrinkingEnum.java
+++ b/src/main/java/com/roommate/domain/member/entity/MemberDrinkingEnum.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberDrinkingEnum {
+    NONE("NONE"),
+    SOCIAL("SOCIAL"),
+    OFTEN("OFTEN");
+
+    private final String drinkingType;
+}

--- a/src/main/java/com/roommate/domain/member/entity/MemberEntity.java
+++ b/src/main/java/com/roommate/domain/member/entity/MemberEntity.java
@@ -1,0 +1,39 @@
+package com.roommate.domain.member.entity;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class MemberEntity {
+
+    private Long memberId;
+    private Long workTypeId;
+    private String email;
+    private String password;
+    private String name;
+    private String phone;
+    private String photoUrl;
+    @Builder.Default
+    private MemberRoleEnum role = MemberRoleEnum.USER;
+    @Builder.Default
+    private int reportCount = 0;
+    @Builder.Default
+    private int deleted = 0;
+    @Builder.Default
+    private LocalDateTime memberCreatedAt = LocalDateTime.now();
+    @Builder.Default
+    private LocalDateTime memberUpdatedAt = LocalDateTime.now();
+    private String sleepTime;
+    @Builder.Default
+    private MemberSmokingEnum smoking = MemberSmokingEnum.NON_SMOKER;
+    @Builder.Default
+    private MemberDrinkingEnum drinking = MemberDrinkingEnum.NONE;
+    private String mbti;
+}

--- a/src/main/java/com/roommate/domain/member/entity/MemberRoleEnum.java
+++ b/src/main/java/com/roommate/domain/member/entity/MemberRoleEnum.java
@@ -6,8 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberRoleEnum {
-	USER("ROLE_USER"),
-	ADMIN("ROLE_ADMIN");
-	
-	private final String authority;
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+    BANNED("BANNED");
+
+    private final String authority;
 }

--- a/src/main/java/com/roommate/domain/member/entity/MemberSmokingEnum.java
+++ b/src/main/java/com/roommate/domain/member/entity/MemberSmokingEnum.java
@@ -1,0 +1,13 @@
+package com.roommate.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSmokingEnum {
+    NON_SMOKER("NON_SMOKER"),
+    SMOKER("SMOKER");
+
+    private final String smokingType;
+}

--- a/src/main/java/com/roommate/domain/member/entity/WorkTypeEntity.java
+++ b/src/main/java/com/roommate/domain/member/entity/WorkTypeEntity.java
@@ -13,7 +13,6 @@ import lombok.ToString;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
 @Data
 public class WorkTypeEntity {
 	private Long workTypeId;

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.roommate.domain.member.repository;
+
+import com.roommate.domain.member.entity.MemberEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Optional;
+
+@Mapper
+public interface MemberRepository {
+
+    void save(MemberEntity memberEntity);
+    Optional<MemberEntity> findById(@Param("memberId") Long memberId);
+    Optional<MemberEntity> findByEmail(@Param("email") String email);
+    void updateMember(MemberEntity memberEntity);
+}

--- a/src/main/resources/mapper/member/member.xml
+++ b/src/main/resources/mapper/member/member.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.member.repository.MemberRepository">
+    <resultMap id="memberMap" type="com.roommate.domain.member.entity.MemberEntity">
+        <id property="memberId" column="member_id"/>
+        <result property="workTypeId" column="work_type_id"/>
+        <result property="email" column="email"/>
+        <result property="password" column="password"/>
+        <result property="name" column="name"/>
+        <result property="phone" column="phone"/>
+        <result property="photoUrl" column="photo_url"/>
+        <result property="role" column="role" javaType="com.roommate.domain.member.entity.MemberRoleEnum"/>
+        <result property="reportCount" column="report_count"/>
+        <result property="deleted" column="deleted"/>
+        <result property="memberCreatedAt" column="member_created_at"/>
+        <result property="memberUpdatedAt" column="member_updated_at"/>
+        <result property="sleepTime" column="sleep_time"/>
+        <result property="smoking" column="smoking" javaType="com.roommate.domain.member.entity.MemberSmokingEnum"/>
+        <result property="drinking" column="drinking" javaType="com.roommate.domain.member.entity.MemberDrinkingEnum"/>
+        <result property="mbti" column="mbti"/>
+    </resultMap>
+
+    <select id="findById" resultMap="memberMap">
+        SELECT *
+        FROM members
+        WHERE member_id = #{memberId}
+    </select>
+    <select id="findByEmail" resultMap="memberMap">
+        SELECT *
+        FROM members
+        WHERE email = #{email}
+    </select>
+    <insert id="save" useGeneratedKeys="true" keyProperty="memberId" parameterType="com.roommate.domain.member.entity.MemberEntity">
+        INSERT INTO members (
+        work_type_id,
+        email,
+        password,
+        name,
+        phone,
+        photo_url,
+        role,
+        report_count,
+        deleted,
+        sleep_time,
+        smoking,
+        drinking,
+        mbti
+        )
+        VALUES (
+        #{workTypeId},
+        #{email},
+        #{password},
+        #{name},
+        #{phone},
+        #{photoUrl},
+        #{role},
+        #{reportCount},
+        #{deleted},
+        #{sleepTime},
+        #{smoking},
+        #{drinking},
+        #{mbti}
+        )
+    </insert>
+    <update id="updateMember" parameterType="com.roommate.domain.member.entity.MemberEntity">
+        UPDATE members
+        <set>
+            work_type_id = #{workTypeId},
+            phone = #{phone},
+            photo_url = #{photoUrl},
+            sleep_time = #{sleepTime},
+            smoking = #{smoking},
+            drinking = #{drinking},
+            mbti = #{mbti},
+            member_updated_at = NOW()
+        </set>
+        WHERE
+            member_id = #{memberId}
+    </update>
+</mapper>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -27,8 +27,19 @@
         <filter-name>encodingFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
+    <!--      Spring Security 필터 체인 등록
+        - 모든 요청(/*)을 가로채서 SecurityConfig에서 정의한
+          인증/인가 필터 흐름을 적용하기 위한 설정
+        - DelegatingFilterProxy가 springSecurityFilterChain 빈을 자동으로 찾아 실행함 -->
+    <filter>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
 
-
+    <filter-mapping>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 	<!-- bean 객체의 컨트롤러 자동 등록 context설정하기 -->
 	<context-param>
 		<param-name>contextConfigLocation</param-name>


### PR DESCRIPTION
 개요
Spring Security와 JWT를 기반으로 한 인증/인가의 뼈대를 구축했습니다.  
이 PR은 이후 회원가입/로그인 기능을 구현하기 위한 보안 인프라 설정을 포함합니다.
 주요 변경 사항

 1. JWT 관련 기능 추가
- `JwtAuthenticationFilter`
  - 매 요청마다 Authorization 헤더의 JWT를 추출
  - 토큰 유효성 검증 후, 사용자 정보를 SecurityContext에 등록
- `JwtUtil`
  - JWT 생성, 파싱, 검증 유틸 (기존 클래스 재사용)

 2. Spring Security 사용자 정보 연동
- `UserDetailsImpl`
  - `MemberEntity`를 기반으로 권한 정보(`ROLE_USER`, `ROLE_ADMIN`)를 `GrantedAuthority`로 변환
- `UserDetailsServiceImpl`
  - 이메일 기준으로 `MemberRepository`에서 회원 조회
  - 조회 실패 시 `UsernameNotFoundException` 발생

 3. Member 관련 엔티티/리포지토리/매퍼 추가
- `MemberEntity`
  - 회원 기본 정보 및 역할/흡연/음주 등 필드 정의
- `MemberRoleEnum`, `MemberSmokingEnum`, `MemberDrinkingEnum`
  - 역할/흡연/음주 상태를 Enum으로 관리
- `MemberRepository`
  - `findById`, `findByEmail`, `save`, `updateMember` 메서드 정의
- `mapper/member/member.xml`
  - Member 엔티티 매핑 및 CRUD SQL 작성

 4. Spring Security 설정
- `SecurityConfig`
  - `PasswordEncoder`(BCrypt) 설정
  - `UserDetailsService` 등록
  - JWT 필터(`JwtAuthenticationFilter`)를 `UsernamePasswordAuthenticationFilter` 앞에 추가
  - 접근 권한 설정
    - `/api/auth/signup`, `/api/auth/login`, `/`, `/index`, `/resources/**`, `/room` → `permitAll`
    - `/api/admin/**` → `ROLE_ADMIN`만 가능
    - 그 외 모든 요청 → 인증 필요
- `web.xml`
  - `springSecurityFilterChain` 필터 등록
 테스트 내용

- 톰캣 서버 기동 확인 (에러 없이 부팅)
- `/room` 페이지 접속 확인
- `/api/members/work-types` 호출 시 정상 응답(JSON)
- Security 필터 체인에 `JwtAuthenticationFilter`가 포함되는지 로그로 확인

> 실제 로그인/회원가입 API는 아직 구현 전이며,  
> 현재는 **보안 구조(뼈대)**까지만 설정된 상태입니다.
 