### PR TITLE
feat: access token 자동 재발급 테스트용 로그인 페이지 및 JS 구성

### DIFF
--- a/src/main/java/com/roommate/common/security/SecurityConfig.java
+++ b/src/main/java/com/roommate/common/security/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.authorizeRequests()
                 .antMatchers("/api/auth/signup", "/api/auth/login","/api/auth/refresh").permitAll()
+                // ★ 테스트용 뷰 페이지 허용
+                .antMatchers("/auth/login-test", "/auth/me-test").permitAll()
                 .antMatchers("/", "/index", "/resources/**", "/room").permitAll()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();

--- a/src/main/java/com/roommate/domain/auth/controller/AuthViewController.java
+++ b/src/main/java/com/roommate/domain/auth/controller/AuthViewController.java
@@ -1,0 +1,24 @@
+package com.roommate.domain.auth.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/auth")
+public class AuthViewController {
+
+    // 로그인 테스트 화면
+    @GetMapping("/login-test")
+    public String loginTestPage() {
+        // /WEB-INF/views/auth/login-test.jsp 로 forward
+        return "auth/login-test";
+    }
+
+    // 내 정보 + 자동 재발급 테스트 화면
+    @GetMapping("/me-test")
+    public String meTestPage() {
+        // /WEB-INF/views/auth/me-test.jsp 로 forward
+        return "auth/me-test";
+    }
+}

--- a/src/main/webapp/WEB-INF/views/auth/login-test.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/login-test.jsp
@@ -1,0 +1,32 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>로그인 테스트</title>
+</head>
+<body>
+<h1>로그인 테스트 페이지</h1>
+
+<form id="loginForm">
+    <div>
+        <label>Email: </label>
+        <input type="text" id="email" value="test@naver.com">
+    </div>
+    <div>
+        <label>Password: </label>
+        <input type="password" id="password" value="12345678">
+    </div>
+    <button type="submit">로그인</button>
+</form>
+
+<hr>
+
+<p>현재 저장된 Access Token:</p>
+<pre id="accessTokenBox"></pre>
+
+<p>현재 저장된 Refresh Token:</p>
+<pre id="refreshTokenBox"></pre>
+
+<script type="module" src="/resources/js/auth/login.js"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/auth/me-test.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/me-test.jsp
@@ -1,0 +1,30 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>내 정보 + 토큰 자동 재발급 테스트</title>
+</head>
+<body>
+<h1>내 정보 조회 테스트</h1>
+
+<button id="loadMeBtn">/api/members/me 호출</button>
+<button id="breakAccessBtn">Access Token 망가뜨리기</button>
+<button id="logoutBtn">로그아웃</button>
+
+<hr>
+
+<h3>내 정보 응답 JSON</h3>
+<pre id="meResult"></pre>
+
+<hr>
+
+<h3>현재 토큰 상태</h3>
+<p>Access Token:</p>
+<pre id="accessTokenBox"></pre>
+
+<p>Refresh Token:</p>
+<pre id="refreshTokenBox"></pre>
+
+<script type="module" src="/resources/js/auth/mypage.js"></script>
+</body>
+</html>

--- a/src/main/webapp/resources/js/auth/apiClient.js
+++ b/src/main/webapp/resources/js/auth/apiClient.js
@@ -1,0 +1,88 @@
+// apiClient.js
+// AccessToken 자동 첨부 + 401 시 RefreshToken으로 재발급 + 재요청
+
+import {
+  getAccessToken,
+  getRefreshToken,
+  getTokenType,
+  saveTokens,
+  clearTokens,
+} from "./authTokenStorage.js";
+
+// 비동기 딜레이(디버깅용으로 쓰고 싶으면 유지, 아니면 삭제 가능)
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// 공통 API 요청 함수
+export async function apiRequest(input, init = {}) {
+  // 1) 기존 옵션 복사
+  const options = { ...init };
+  options.headers = {
+    ...(init.headers || {}),
+    "Content-Type":
+      init.headers && init.headers["Content-Type"]
+        ? init.headers["Content-Type"]
+        : "application/json",
+  };
+
+  const accessToken = getAccessToken();
+  if (accessToken) {
+    options.headers["Authorization"] = `${getTokenType()} ${accessToken}`;
+  }
+
+  // 1차 요청
+  let response = await fetch(input, options);
+
+  // 401 아니면 그대로 반환
+  if (response.status !== 401) {
+    return response;
+  }
+
+  // 401 → AccessToken 만료 가능성 → Refresh 시도
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) {
+    // RefreshToken도 없으면 그냥 로그아웃 처리
+    clearTokens();
+    alert("로그인이 만료되었습니다. 다시 로그인 해주세요.");
+    // 필요하면 location.href = "/login"; 이런 거 추가
+    return response;
+  }
+
+  // 2) Refresh 요청
+  const refreshResponse = await fetch("/api/auth/refresh", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!refreshResponse.ok) {
+    // refresh 실패 → 토큰 삭제 후 로그인 페이지로 유도
+    clearTokens();
+    alert("세션이 만료되었습니다. 다시 로그인 해주세요.");
+    return response;
+  }
+
+  const refreshData = await refreshResponse.json();
+
+  // 응답 필드 이름은 서버 snake_case 기준
+  saveTokens({
+    accessToken: refreshData.access_token,
+    refreshToken: refreshData.refresh_token,
+    tokenType: refreshData.token_type,
+  });
+
+  // 🔁 새 AccessToken으로 원래 요청 다시 한번 시도
+  const retryOptions = { ...options };
+  retryOptions.headers = {
+    ...(options.headers || {}),
+    Authorization: `${refreshData.token_type} ${refreshData.access_token}`,
+  };
+
+  const retryResponse = await fetch(input, retryOptions);
+  return retryResponse;
+}

--- a/src/main/webapp/resources/js/auth/authTokenStorage.js
+++ b/src/main/webapp/resources/js/auth/authTokenStorage.js
@@ -1,0 +1,34 @@
+// authTokenStorage.js
+// - 토큰 저장/조회/삭제를 한 곳에서 관리하기 위한 유틸리티
+// - 나중에 localStorage -> cookie로 바꾸고 싶어도 이 파일만 바꾸면 되도록 분리함
+
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+const TOKEN_TYPE_KEY = "token_type";
+
+// 로그인 성공 시 토큰을 저장
+export function saveTokens({ accessToken, refreshToken, tokenType }) {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  localStorage.setItem(TOKEN_TYPE_KEY, tokenType || "Bearer");
+}
+
+// 저장된 토큰 가져오기
+export function getAccessToken() {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function getTokenType() {
+  return localStorage.getItem(TOKEN_TYPE_KEY) || "Bearer";
+}
+
+// 로그아웃 시 토큰 제거
+export function clearTokens() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  localStorage.removeItem(TOKEN_TYPE_KEY);
+}

--- a/src/main/webapp/resources/js/auth/login.js
+++ b/src/main/webapp/resources/js/auth/login.js
@@ -1,0 +1,45 @@
+// login-test.js
+import { saveTokens, getAccessToken, getRefreshToken } from "./authTokenStorage.js";
+
+function renderTokens() {
+  document.querySelector("#accessTokenBox").textContent =
+    getAccessToken() || "(없음)";
+  document.querySelector("#refreshTokenBox").textContent =
+    getRefreshToken() || "(없음)";
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+
+  const email = document.querySelector("#email").value;
+  const password = document.querySelector("#password").value;
+
+  const res = await fetch("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!res.ok) {
+    alert("로그인 실패: " + res.status);
+    return;
+  }
+
+  const data = await res.json();
+
+  // 서버 응답 필드명(snake_case)에 맞게
+  saveTokens({
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    tokenType: data.token_type,
+  });
+
+  alert("로그인 성공!");
+  renderTokens();
+}
+
+document
+  .querySelector("#loginForm")
+  .addEventListener("submit", handleLogin);
+
+document.addEventListener("DOMContentLoaded", renderTokens);

--- a/src/main/webapp/resources/js/auth/mypage.js
+++ b/src/main/webapp/resources/js/auth/mypage.js
@@ -1,0 +1,66 @@
+// me-test.js
+import {
+  getAccessToken,
+  getRefreshToken,
+  saveTokens,
+  clearTokens,
+} from "./authTokenStorage.js";
+import { apiRequest } from "./apiClient.js";
+
+function renderTokens() {
+  document.querySelector("#accessTokenBox").textContent =
+    getAccessToken() || "(없음)";
+  document.querySelector("#refreshTokenBox").textContent =
+    getRefreshToken() || "(없음)";
+}
+
+// /api/members/me 호출
+async function handleLoadMe() {
+  const res = await apiRequest("/api/members/me", { method: "GET" });
+
+  const text = await res.text(); // JSON 이지만 일단 보기 쉽게 text로
+  document.querySelector("#meResult").textContent = text;
+
+  renderTokens();
+}
+
+// Access Token 일부러 망가뜨리기 (자동 /refresh 테스트용)
+function handleBreakAccessToken() {
+  const token = getAccessToken();
+  if (!token) {
+    alert("Access Token이 없습니다. 먼저 로그인 해주세요.");
+    return;
+  }
+
+  const broken = token.substring(0, 10); // 앞 10글자만 남겨서 망가뜨림
+  saveTokens({
+    accessToken: broken,
+    refreshToken: getRefreshToken(),
+    tokenType: "Bearer",
+  });
+
+  alert("Access Token을 일부러 망가뜨렸습니다. 이제 /me 호출 시 자동 /refresh 되는지 확인하세요.");
+  renderTokens();
+}
+
+// 로그아웃 (서버 + 클라이언트 토큰 삭제)
+async function handleLogout() {
+  try {
+    await apiRequest("/api/auth/logout", { method: "POST" });
+  } catch (e) {
+    console.warn("서버 로그아웃 실패, 클라이언트 토큰만 삭제:", e);
+  } finally {
+    clearTokens();
+    renderTokens();
+    document.querySelector("#meResult").textContent = "";
+    alert("로그아웃 완료 (토큰 삭제)");
+  }
+}
+
+document.querySelector("#loadMeBtn").addEventListener("click", handleLoadMe);
+document
+  .querySelector("#breakAccessBtn")
+  .addEventListener("click", handleBreakAccessToken);
+document.querySelector("#logoutBtn").addEventListener("click", handleLogout);
+
+document.addEventListener("DOMContentLoaded", renderTokens);


### PR DESCRIPTION
1. 개요

Access Token / Refresh Token 기능을 프론트에서 실제로 호출해 보기 위해  
간단한 로그인 테스트 페이지 + JS를 추가했습니다.

이번 PR은 실제 서비스용 UI가 아니라, 개발용/테스트용 페이지를 추가하는 것이 목적입니다.

 2. 주요 변경 사항

 2-1. 로그인 테스트 페이지 추가

AuthViewController 추가
GET /auth/login-test 요청 시 테스트용 JSP 반환
JSP 뷰 추가
src/main/webapp/WEB-INF/views/auth/login-test.jsp
이메일 / 비밀번호 입력 폼
응답 Access Token / Refresh Token / 상태 메시지를 화면에 보여주는 영역 추가

2-2. JWT 테스트용 JS 추가

src/main/webapp/resources/js/auth/login.js
/api/auth/login 호출
응답으로 받은 accessToken, refreshToken을 화면에 출력
토큰을 localStorage 에 보관하여 다음 요청에서 재사용 가능하게 처리
/api/auth/refresh를 호출해 Refresh Token으로 Access Token 재발급 테스트 가능하도록 구성
/api/auth/logout 호출 버튼 추가 (Refresh Token 삭제 테스트용)

src/main/webapp/resources/js/auth/authTokenStorage.js (있다면)
Access / Refresh Token을 브라우저 localStorage 에 저장/조회/삭제하는 유틸 함수 분리

2-3. SecurityConfig 수정

/auth/** 경로를 permitAll()로 설정
로그인 테스트 페이지 접속 시 403 에러가 발생하지 않도록 허용
정적 리소스 JS 경로(/resources/**)는 기존 설정을 그대로 사용
CORS 설정에서 `Authorization` 헤더 노출(exposedHeaders)에 이미 포함되어 있어,  
프론트에서 토큰 확인 가능

3. 테스트 방법

1. 로그인 테스트 페이지 접속
브라우저에서 http://localhost:9090/auth/login-test 접속

2. 로그인 요청
테스트용 계정 정보 입력
로그인 버튼 클릭
화면의 Access Token / Refresh Token 출력 영역에 토큰이 정상 표시되는지 확인
개발자 도구 → Application → Local Storage 에 토큰이 저장되었는지 확인

3. Refresh Token 재발급 테스트
Access Token 재발급 테스트 버튼(또는 refresh 버튼)이 있다면 클릭
/api/auth/refresh 호출이 성공하고, 새 Access Token 이 화면에 다시 표시되는지 확인

4. 로그아웃 테스트
로그아웃 버튼 클릭
서버에서 /api/auth/logout 호출 후, DB의 token_refresh 레코드 삭제 확인
브라우저 localStorage의 토큰이 삭제되었는지도 확인

4. 기타 참고사항
 이 페이지는 개발/테스트 편의를 위한 임시 페이지로,  
실제 서비스 화면에서 제거하거나 관리자용 페이지로 숨길 예정입니다.
