### PR TITLE
feat: Access Token 만료 시 Refresh Token 자동 재발급 처리

### DIFF
--- a/src/main/webapp/WEB-INF/views/auth/login-test.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/login-test.jsp
@@ -27,6 +27,6 @@
 <p>현재 저장된 Refresh Token:</p>
 <pre id="refreshTokenBox"></pre>
 
-<script type="module" src="/resources/js/auth/login.js"></script>
+<script type="module" src="/resources/js/auth/login-test.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/auth/me-test.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/me-test.jsp
@@ -25,6 +25,6 @@
 <p>Refresh Token:</p>
 <pre id="refreshTokenBox"></pre>
 
-<script type="module" src="/resources/js/auth/mypage.js"></script>
+<script type="module" src="/resources/js/auth/me-test.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/js/auth/login-test.js
+++ b/src/main/webapp/resources/js/auth/login-test.js
@@ -1,5 +1,5 @@
 // login-test.js
-import { saveTokens, getAccessToken, getRefreshToken } from "./authTokenStorage.js";
+import { saveTokens, getAccessToken, getRefreshToken } from "../common/authTokenStorage.js";
 
 function renderTokens() {
   document.querySelector("#accessTokenBox").textContent =

--- a/src/main/webapp/resources/js/auth/me-test.js
+++ b/src/main/webapp/resources/js/auth/me-test.js
@@ -4,8 +4,8 @@ import {
   getRefreshToken,
   saveTokens,
   clearTokens,
-} from "./authTokenStorage.js";
-import { apiRequest } from "./apiClient.js";
+} from "../common/authTokenStorage.js";
+import { apiRequest } from "../common/apiClient.js";
 
 function renderTokens() {
   document.querySelector("#accessTokenBox").textContent =

--- a/src/main/webapp/resources/js/common/apiClient.js
+++ b/src/main/webapp/resources/js/common/apiClient.js
@@ -56,7 +56,7 @@ export async function apiRequest(input, init = {}) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      refresh_token: refreshToken,
+      refreshToken: refreshToken,
     }),
   });
 
@@ -71,16 +71,16 @@ export async function apiRequest(input, init = {}) {
 
   // 응답 필드 이름은 서버 snake_case 기준
   saveTokens({
-    accessToken: refreshData.access_token,
-    refreshToken: refreshData.refresh_token,
-    tokenType: refreshData.token_type,
+    accessToken: refreshData.accessToken,
+    refreshToken: refreshData.refreshToken,
+    tokenType: refreshData.tokenType,
   });
 
   // 🔁 새 AccessToken으로 원래 요청 다시 한번 시도
   const retryOptions = { ...options };
   retryOptions.headers = {
     ...(options.headers || {}),
-    Authorization: `${refreshData.token_type} ${refreshData.access_token}`,
+    Authorization: `${refreshData.tokenType} ${refreshData.accessToken}`,
   };
 
   const retryResponse = await fetch(input, retryOptions);

--- a/src/main/webapp/resources/js/common/authTokenStorage.js
+++ b/src/main/webapp/resources/js/common/authTokenStorage.js
@@ -2,9 +2,9 @@
 // - 토큰 저장/조회/삭제를 한 곳에서 관리하기 위한 유틸리티
 // - 나중에 localStorage -> cookie로 바꾸고 싶어도 이 파일만 바꾸면 되도록 분리함
 
-const ACCESS_TOKEN_KEY = "access_token";
-const REFRESH_TOKEN_KEY = "refresh_token";
-const TOKEN_TYPE_KEY = "token_type";
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+const TOKEN_TYPE_KEY = "tokenType";
 
 // 로그인 성공 시 토큰을 저장
 export function saveTokens({ accessToken, refreshToken, tokenType }) {


### PR DESCRIPTION
 작업 내용
Access Token 만료(401) 발생 시,
프론트엔드에서 Refresh Token을 이용하여 자동으로 Access Token을 재발급하고
기존 API 요청을 자동으로 재시도하는 기능을 구현했습니다.

주요 작업
 공용 토큰 관리 유틸 분리
   authTokenStorage.js (Access / Refresh / TokenType 저장 및 관리)
공용 API 요청 모듈 분리
   apiClient.js (Authorization 자동 첨부 + 401 시 자동 refresh + 재요청)
테스트 페이지 추가
   login-test.jsp / login-test.js
   me-test.jsp / me-test.js
기존 auth 하위 js → common 폴더로 구조 개선

테스트 방법
1. /auth/login-test 접속
2. 로그인 후 Access Token / Refresh Token 정상 발급 확인
3. /auth/me-test 접속
4. Access Token 일부러 깨기 버튼 클릭
5. /api/members/me 호출 시
   401 발생 → /api/auth/refresh 자동 호출
   새 Access Token 발급 → 기존 요청 자동 재시도
6. 정상 응답 확인

기대 효과
 사용자는 Access Token 만료를 인지하지 못한 채 서비스 이용 가능
 이후 모든 API 요청은 `apiClient.js` 를 통해 공통 처리 가능
 실서비스 로그인/마이페이지 연동을 위한 기반 구조 완성

 관련 이슈
11 Access Token 만료 시 Refresh Token 자동 재발급 처리