### PR TITLE
[#15] 로그인/회원가입 모달 및 JWT 인증, 회원 코드 조회 API 구현

### DIFF
--- a/src/main/java/com/roommate/common/security/SecurityConfig.java
+++ b/src/main/java/com/roommate/common/security/SecurityConfig.java
@@ -58,9 +58,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.cors();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.authorizeRequests()
-                .antMatchers("/api/auth/signup", "/api/auth/login","/api/auth/refresh").permitAll()
+                .antMatchers("/api/auth/signup", "/api/auth/login","/api/auth/refresh","/api/members/form-codes").permitAll()
                 // ★ 테스트용 뷰 페이지 허용
-                .antMatchers("/auth/login-test", "/auth/me-test").permitAll()
+                .antMatchers("/auth/login-test", "/auth/me-test", "/auth/login","/room/main").permitAll()
                 .antMatchers("/", "/index", "/resources/**", "/room").permitAll()
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();

--- a/src/main/java/com/roommate/domain/auth/controller/AuthViewController.java
+++ b/src/main/java/com/roommate/domain/auth/controller/AuthViewController.java
@@ -21,4 +21,11 @@ public class AuthViewController {
         // /WEB-INF/views/auth/me-test.jsp 로 forward
         return "auth/me-test";
     }
+
+    // 로그인 화면
+    @GetMapping("/login")
+    public String loginPage() {
+        // /WEB-INF/views/auth/login.jsp 로 forward
+        return "auth/login";
+    }
 }

--- a/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
@@ -4,13 +4,12 @@ import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
 import lombok.Data;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
+import java.util.List;
 
 @Data
 public class SignUpRequest {
+    @NotNull(message = "직업/라이프스타일을 선택해주세요")
     private Long workTypeId;
     @NotBlank(message = "이메일을 입력해주세요")
     @Email(message = "잘못된 이메일 입니다")
@@ -24,8 +23,17 @@ public class SignUpRequest {
     private String phone;
     @Size(max = 255)
     private String photoUrl;
+
     private String sleepTime;
+
+    @NotNull(message = "흡연 여부를 선택해주세요")
     private MemberSmokingEnum smoking;
+
+    @NotNull(message = "음주 여부를 선택해주세요")
     private MemberDrinkingEnum drinking;
     private String mbti;
+
+    private List<Long> hobbyIds;
+    private List<Long> preferenceIds;
+    private List<Long> petIds;
 }

--- a/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
@@ -18,6 +18,7 @@ import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -58,8 +59,9 @@ public class AuthServiceImpl implements AuthService {
         memberEntity.setPhotoUrl(signUpRequest.getPhotoUrl());
         memberEntity.setSleepTime(signUpRequest.getSleepTime());
         memberEntity.setWorkTypeId(signUpRequest.getWorkTypeId());
-        memberEntity.setSmoking(signUpRequest.getSmoking());
-        memberEntity.setDrinking(signUpRequest.getDrinking());
+        // 흡연/음주 기본값 처리
+        memberEntity.setSmoking(signUpRequest.getSmoking() != null ? signUpRequest.getSmoking() : MemberSmokingEnum.NON_SMOKER);
+        memberEntity.setDrinking(signUpRequest.getDrinking() != null ? signUpRequest.getDrinking() : MemberDrinkingEnum.NONE);
         memberEntity.setMbti(signUpRequest.getMbti());
         return memberEntity;
     }
@@ -105,10 +107,31 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
         validateEmailDuplication(signUpRequest.getEmail());
         MemberEntity memberEntity = createMemberFromSignUpRequest(signUpRequest);
         memberRepository.save(memberEntity);
+        Long memberId = memberEntity.getMemberId();
+
+        if (signUpRequest.getHobbyIds() != null) {
+            for (Long hobbyId : signUpRequest.getHobbyIds()) {
+                memberRepository.insertMemberHobby(memberId, hobbyId);
+            }
+        }
+
+        if (signUpRequest.getPreferenceIds() != null) {
+            for (Long preferenceId : signUpRequest.getPreferenceIds()) {
+                memberRepository.insertMemberPreference(memberId, preferenceId);
+            }
+        }
+
+        if (signUpRequest.getPetIds() != null) {
+            for (Long petId : signUpRequest.getPetIds()) {
+                memberRepository.insertMemberPet(memberId, petId);
+            }
+        }
+
         SignUpResponse response = toSignUpResponse(memberEntity);
         return response;
     }

--- a/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
@@ -1,6 +1,7 @@
 package com.roommate.domain.member.controller;
 
 import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
 import com.roommate.domain.member.service.MemberService;
@@ -25,7 +26,7 @@ public class MemberRestController {
      */
     @GetMapping("/work-types")
     public ResponseEntity<List<WorkTypeResponse>> getAllWorkTypes(){
-        List<WorkTypeResponse> workTypes = memberService.findAllWorkType();
+        List<WorkTypeResponse> workTypes = memberService.getFormCodes().getWorkTypes();
         return ResponseEntity.ok(workTypes);
     }
 
@@ -35,4 +36,13 @@ public class MemberRestController {
         return ResponseEntity.ok(memberResponse);
     }
 
+    /**
+     * 회원가입 / 프로필 수정 화면에서 사용하는
+     * 공통 코드(직업, 취미, 생활 선호, 반려동물)를 한 번에 조회합니다.
+     *
+     */
+    @GetMapping("/form-codes")
+    public ResponseEntity<FormCodesResponse> getFormCodes() {
+        return ResponseEntity.ok(memberService.getFormCodes());
+    }
 }

--- a/src/main/java/com/roommate/domain/member/dto/response/FormCodesResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/FormCodesResponse.java
@@ -1,0 +1,13 @@
+package com.roommate.domain.member.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FormCodesResponse {
+    private List<WorkTypeResponse> workTypes;
+    private List<HobbyResponse> hobbies;
+    private List<PreferenceResponse> preferences;
+    private List<PetResponse> pets;
+}

--- a/src/main/java/com/roommate/domain/member/dto/response/HobbyResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/HobbyResponse.java
@@ -1,0 +1,9 @@
+package com.roommate.domain.member.dto.response;
+
+import lombok.Data;
+
+@Data
+public class HobbyResponse {
+    private Long HobbyId;
+    private String HobbyName;
+}

--- a/src/main/java/com/roommate/domain/member/dto/response/PetResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/PetResponse.java
@@ -1,0 +1,9 @@
+package com.roommate.domain.member.dto.response;
+
+import lombok.Data;
+
+@Data
+public class PetResponse {
+    private Long PetId;
+    private String PetName;
+}

--- a/src/main/java/com/roommate/domain/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/PreferenceResponse.java
@@ -1,0 +1,9 @@
+package com.roommate.domain.member.dto.response;
+
+import lombok.Data;
+
+@Data
+public class PreferenceResponse {
+    private Long PreferenceId;
+    private String PreferenceName;
+}

--- a/src/main/java/com/roommate/domain/member/entity/HobbyEntity.java
+++ b/src/main/java/com/roommate/domain/member/entity/HobbyEntity.java
@@ -1,19 +1,21 @@
 package com.roommate.domain.member.entity;
 
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-public class WorkTypeEntity {
-	private Long workTypeId;
-	private String workTypeName;
-	private LocalDateTime createdAt;
+public class HobbyEntity {
+    private Long hobbyId;
+    private String hobbyName;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/roommate/domain/member/entity/PetEntity.java
+++ b/src/main/java/com/roommate/domain/member/entity/PetEntity.java
@@ -1,19 +1,21 @@
 package com.roommate.domain.member.entity;
 
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-public class WorkTypeEntity {
-	private Long workTypeId;
-	private String workTypeName;
-	private LocalDateTime createdAt;
+public class PetEntity {
+    private Long petId;
+    private String petName;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/roommate/domain/member/entity/PreferenceEntity.java
+++ b/src/main/java/com/roommate/domain/member/entity/PreferenceEntity.java
@@ -1,19 +1,21 @@
 package com.roommate.domain.member.entity;
 
-import java.time.LocalDateTime;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-public class WorkTypeEntity {
-	private Long workTypeId;
-	private String workTypeName;
-	private LocalDateTime createdAt;
+public class PreferenceEntity {
+    private Long preferenceId;
+    private String preferenceName;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/roommate/domain/member/repository/HobbyRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/HobbyRepository.java
@@ -1,0 +1,11 @@
+package com.roommate.domain.member.repository;
+
+import com.roommate.domain.member.entity.HobbyEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface HobbyRepository {
+    List<HobbyEntity> findAll();
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -17,4 +17,10 @@ public interface MemberRepository {
 
     void updateMember(MemberEntity memberEntity);
 
+    void insertMemberHobby(@Param("memberId") Long memberId, @Param("hobbyId") Long hobbyId);
+
+    void insertMemberPreference(@Param("memberId") Long memberId, @Param("preferenceId") Long preferenceId);
+
+    void insertMemberPet(@Param("memberId") Long memberId, @Param("petId") Long petId);
+
 }

--- a/src/main/java/com/roommate/domain/member/repository/PetRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/PetRepository.java
@@ -1,0 +1,11 @@
+package com.roommate.domain.member.repository;
+
+import com.roommate.domain.member.entity.PetEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PetRepository {
+    List<PetEntity> findAll();
+}

--- a/src/main/java/com/roommate/domain/member/repository/PreferenceRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/PreferenceRepository.java
@@ -1,0 +1,11 @@
+package com.roommate.domain.member.repository;
+
+import com.roommate.domain.member.entity.PreferenceEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PreferenceRepository {
+    List<PreferenceEntity> findAll();
+}

--- a/src/main/java/com/roommate/domain/member/service/MemberService.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberService.java
@@ -2,15 +2,19 @@ package com.roommate.domain.member.service;
 
 import java.util.List;
 
+import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
 
 public interface MemberService {
 
-	public List<WorkTypeResponse> findAllWorkType();
-
 	/**
 	 * 회원조회
 	 */
 	public MemberResponse memberInfo(Long memberId);
+
+	/**
+	 *
+	 */
+	public FormCodesResponse getFormCodes();
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
@@ -4,16 +4,10 @@ import java.util.List;
 
 import com.roommate.common.exception.ApiException;
 import com.roommate.common.exception.ErrorCode;
-import com.roommate.domain.member.dto.response.MemberResponse;
-import com.roommate.domain.member.dto.response.WorkTypeResponse;
-import com.roommate.domain.member.entity.MemberDrinkingEnum;
-import com.roommate.domain.member.entity.MemberEntity;
-import com.roommate.domain.member.entity.MemberSmokingEnum;
-import com.roommate.domain.member.repository.MemberRepository;
+import com.roommate.domain.member.dto.response.*;
+import com.roommate.domain.member.entity.*;
+import com.roommate.domain.member.repository.*;
 import org.springframework.stereotype.Service;
-
-import com.roommate.domain.member.entity.WorkTypeEntity;
-import com.roommate.domain.member.repository.WorkTypeRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,12 +17,36 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final WorkTypeRepository workTypeRepository;
+    private final HobbyRepository hobbyRepository;
+    private final PreferenceRepository preferenceRepository;
+    private final PetRepository petRepository;
 
     private WorkTypeResponse toWorkTypeResponse(WorkTypeEntity workTypeEntity) {
         WorkTypeResponse workTypeResponse = new WorkTypeResponse();
         workTypeResponse.setWorkTypeId(workTypeEntity.getWorkTypeId());
         workTypeResponse.setWorkTypeName(workTypeEntity.getWorkTypeName());
         return workTypeResponse;
+    }
+
+    private HobbyResponse toHobbyResponse(HobbyEntity hobbyEntity) {
+        HobbyResponse hobbyResponse = new HobbyResponse();
+        hobbyResponse.setHobbyId(hobbyEntity.getHobbyId());
+        hobbyResponse.setHobbyName(hobbyEntity.getHobbyName());
+        return hobbyResponse;
+    }
+
+    private PreferenceResponse toPreferenceResponse(PreferenceEntity preferenceEntity) {
+        PreferenceResponse preferenceResponse = new PreferenceResponse();
+        preferenceResponse.setPreferenceId(preferenceEntity.getPreferenceId());
+        preferenceResponse.setPreferenceName(preferenceEntity.getPreferenceName());
+        return preferenceResponse;
+    }
+
+    private PetResponse toPetResponse(PetEntity petEntity) {
+        PetResponse petResponse = new PetResponse();
+        petResponse.setPetId(petEntity.getPetId());
+        petResponse.setPetName(petEntity.getPetName());
+        return petResponse;
     }
 
     private MemberResponse toMemberResponse(MemberEntity memberEntity, String workTypeName) {
@@ -47,8 +65,13 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public List<WorkTypeResponse> findAllWorkType() {
-        return workTypeRepository.findAll().stream().map(this::toWorkTypeResponse).toList();
+    public FormCodesResponse getFormCodes() {
+        FormCodesResponse formCodesResponse = new FormCodesResponse();
+        formCodesResponse.setWorkTypes(workTypeRepository.findAll().stream().map(this::toWorkTypeResponse).toList());
+        formCodesResponse.setHobbies(hobbyRepository.findAll().stream().map(this::toHobbyResponse).toList());
+        formCodesResponse.setPreferences(preferenceRepository.findAll().stream().map(this::toPreferenceResponse).toList());
+        formCodesResponse.setPets(petRepository.findAll().stream().map(this::toPetResponse).toList());
+        return formCodesResponse;
     }
 
     @Override

--- a/src/main/resources/mapper/member/hobby.xml
+++ b/src/main/resources/mapper/member/hobby.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.HobbyRepository">
+
+    <resultMap id="hobbyMap" type="com.roommate.domain.member.entity.HobbyEntity">
+        <id property="hobbyId" column="hobby_id"/>
+        <result property="hobbyName" column="hobby_name"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="hobbyMap">
+        SELECT *
+        FROM hobbies
+        ORDER BY hobby_name
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/member/member.xml
+++ b/src/main/resources/mapper/member/member.xml
@@ -65,6 +65,20 @@
         #{mbti}
         )
     </insert>
+    <insert id="insertMemberHobby">
+        INSERT INTO member_hobbies (member_id, hobby_id)
+        VALUES (#{memberId}, #{hobbyId})
+    </insert>
+
+    <insert id="insertMemberPreference">
+        INSERT INTO member_preferences (member_id, preference_id)
+        VALUES (#{memberId}, #{preferenceId})
+    </insert>
+
+    <insert id="insertMemberPet">
+        INSERT INTO member_pets (member_id, pet_id)
+        VALUES (#{memberId}, #{petId})
+    </insert>
     <update id="updateMember" parameterType="com.roommate.domain.member.entity.MemberEntity">
         UPDATE members
         <set>

--- a/src/main/resources/mapper/member/pet.xml
+++ b/src/main/resources/mapper/member/pet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.PetRepository">
+
+    <resultMap id="petMap" type="com.roommate.domain.member.entity.PetEntity">
+        <id property="petId" column="pet_id"/>
+        <result property="petName" column="pet_name"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="petMap">
+        SELECT *
+        FROM pets
+        ORDER BY pet_name
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/member/preference.xml
+++ b/src/main/resources/mapper/member/preference.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.PreferenceRepository">
+    <resultMap id="preferenceMap" type="com.roommate.domain.member.entity.PreferenceEntity">
+        <id property="preferenceId" column="preference_id"/>
+        <result property="preferenceName" column="preference_name"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="preferenceMap">
+        SELECT *
+        FROM preferences
+        ORDER BY preference_name
+    </select>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/auth/login.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/login.jsp
@@ -1,0 +1,158 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+  <title>Roommate</title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/login.css">
+</head>
+<body>
+
+<div id="authModal" class="auth-modal hidden">
+  <div class="auth-modal-backdrop" onclick="closeAuthModal()"></div>
+
+  <div class="auth-modal-box">
+    <div class="auth-tabs">
+      <button class="auth-tab active" data-tab="login">로그인</button>
+      <button class="auth-tab" data-tab="register">회원가입</button>
+    </div>
+
+    <!-- 로그인 -->
+    <div class="auth-tab-content" id="loginTab">
+      <form id="loginForm">
+        <input type="email" id="loginEmail" placeholder="이메일" required />
+        <input type="password" id="loginPassword" placeholder="비밀번호" required />
+        <button type="submit">로그인</button>
+        <p id="loginError" class="error"></p>
+      </form>
+    </div>
+
+    <!-- 회원가입 탭 -->
+    <div id="registerTab" class="auth-tab-content hidden">
+      <form id="registerForm">
+        <!-- 1. 기본 정보: 이름 -->
+        <div class="form-row">
+          <div class="form-group">
+            <label for="regName">이름</label>
+            <input type="text" id="regName" placeholder="실명을 입력하세요" required>
+          </div>
+        </div>
+
+        <!-- 2. 이메일 -->
+        <div class="form-group">
+          <label for="regEmail">이메일</label>
+          <input type="email" id="regEmail" placeholder="example@email.com" required>
+        </div>
+
+        <!-- 3. 전화번호 -->
+        <div class="form-group">
+          <label for="regPhone">전화번호</label>
+          <input type="text" id="regPhone" placeholder="010-1234-5678" required>
+        </div>
+
+        <!-- 4. 비밀번호 / 비밀번호 확인 -->
+        <div class="form-row">
+          <div class="form-group">
+            <label for="regPassword">비밀번호</label>
+            <input type="password" id="regPassword" placeholder="비밀번호" required>
+          </div>
+
+          <div class="form-group">
+            <label for="regConfirm">비밀번호 확인</label>
+            <input type="password" id="regConfirm" placeholder="비밀번호 확인" required>
+          </div>
+        </div>
+
+        <!-- 5. 흡연 여부 -->
+        <div class="form-group">
+          <label for="regSmoking">흡연 여부</label>
+          <select id="regSmoking" required>
+            <option value="NON_SMOKER">비흡연</option>
+            <option value="SMOKER">흡연</option>
+          </select>
+        </div>
+
+        <!-- 6. 음주 여부 -->
+        <div class="form-group">
+          <label for="regDrinking">음주 여부</label>
+          <select id="regDrinking" required>
+            <option value="NONE">안 함</option>
+            <option value="SOCIAL">가끔</option>
+            <option value="OFTEN">자주</option>
+          </select>
+        </div>
+
+        <!-- 7. 취침 시간 -->
+        <div class="form-group">
+          <label for="regSleepTime">취침 시간</label>
+          <select id="regSleepTime">
+            <option value="">선택 안 함</option>
+            <option value="EARLY">일찍 잠 (22시 이전)</option>
+            <option value="NORMAL">보통 (22~24시)</option>
+            <option value="LATE">늦게 잠 (자정 이후)</option>
+          </select>
+        </div>
+
+        <!-- 8. 직업/생활 타입 (work_type_id) -->
+        <div class="form-group">
+          <label for="regWorkType">직업 / 라이프스타일</label>
+          <select id="regWorkType" required>
+            <!-- JS에서 /api/members/work-types or /form-codes로 옵션 채움 -->
+          </select>
+        </div>
+
+        <!-- 9. MBTI -->
+        <div class="form-group">
+          <label for="regMbti">MBTI</label>
+          <select id="regMbti">
+            <option value="">선택 안 함</option>
+            <option value="INTJ">INTJ</option><option value="INTP">INTP</option>
+            <option value="INFJ">INFJ</option><option value="INFP">INFP</option>
+            <option value="ISTJ">ISTJ</option><option value="ISTP">ISTP</option>
+            <option value="ISFJ">ISFJ</option><option value="ISFP">ISFP</option>
+            <option value="ENTJ">ENTJ</option><option value="ENTP">ENTP</option>
+            <option value="ENFJ">ENFJ</option><option value="ENFP">ENFP</option>
+            <option value="ESTJ">ESTJ</option><option value="ESTP">ESTP</option>
+            <option value="ESFJ">ESFJ</option><option value="ESFP">ESFP</option>
+          </select>
+        </div>
+
+        <!-- 10. 프로필 사진 URL -->
+        <div class="form-group">
+          <label for="regPhoto">프로필 사진 URL (선택)</label>
+          <input type="text" id="regPhoto" placeholder="https://example.com/photo.jpg">
+        </div>
+
+        <!-- 11. 취미 다중 선택 -->
+        <div class="form-group">
+          <label>취미</label>
+          <div id="hobbyCheckboxList" class="checkbox-grid">
+            <!-- JS에서 /api/members/hobbies or form-codes로 채움 -->
+          </div>
+        </div>
+
+        <!-- 12. 생활 선호(성향) 다중 선택 -->
+        <div class="form-group">
+          <label>생활 선호</label>
+          <div id="preferenceCheckboxList" class="checkbox-grid">
+            <!-- JS에서 /api/members/preferences or form-codes로 채움 -->
+          </div>
+        </div>
+
+        <!-- 13. 반려동물 다중 선택 -->
+        <div class="form-group">
+          <label>반려동물</label>
+          <div id="petCheckboxList" class="checkbox-grid">
+            <!-- JS에서 /api/members/pets or form-codes로 채움 -->
+          </div>
+        </div>
+
+        <p id="registerError" class="form-error"></p>
+
+        <button type="submit" class="btn-primary w-100">
+          회원가입
+        </button>
+      </form>
+    </div>
+  </div> <!-- /auth-modal-box -->
+</div>   <!-- /authModal -->
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -1,0 +1,12 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+<div class="header">
+  <div class="logo">Roommate</div>
+
+  <div class="header-right">
+    <button id="btnOpenLogin" type="button">로그인</button>
+    <button id="btnOpenRegister" type="button">회원가입</button>
+    <button id="btnLogout" type="button">로그아웃</button>
+  </div>
+</div>
+
+<jsp:include page="/WEB-INF/views/auth/login.jsp"/>

--- a/src/main/webapp/WEB-INF/views/room/main.jsp
+++ b/src/main/webapp/WEB-INF/views/room/main.jsp
@@ -7,8 +7,10 @@
 <title>Insert title here</title>
 </head>
 <body>
+    <jsp:include page="/WEB-INF/views/common/header.jsp"/>
 	<div id="map" style="width:500px;height:400px;"></div>
 	<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoMapKey}"></script>
-	<script src="${pageContext.request.contextPath}/resources/js/map/map.js"></script>
+	<script src="/resources/js/map/map.js"></script>
+	<script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/login.css
+++ b/src/main/webapp/resources/css/login.css
@@ -1,0 +1,206 @@
+.hidden {
+  display: none !important;
+}
+
+/* 모달 전체 레이어 */
+.auth-modal {
+  position: fixed;
+  inset: 0;               /* top:0; right:0; bottom:0; left:0; 와 같음 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+/* 반투명 배경 */
+.auth-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 0;
+}
+
+/* 실제 내용 박스 */
+.auth-modal-box {
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  width: 420px;
+  max-width: 90vw;
+
+  /* 🔥 이 두 줄이 핵심 */
+  max-height: 90vh;       /* 화면 높이 기준 최대 높이 */
+  overflow-y: auto;       /* 내용이 넘치면 안에서 스크롤 */
+
+  position: relative;  /* 스스로도 위치 지정 */
+  z-index: 1;          /* backdrop(z-index:0)보다 위 */
+}
+
+/* 탭 영역 */
+.auth-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  margin-bottom: 18px;
+  background: #f3f4f6;
+  padding: 3px;
+  border-radius: 999px;
+}
+
+/* 탭 버튼 */
+.auth-tab {
+  border: none;
+  background: transparent;
+  padding: 8px 0;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #4b5563;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.auth-tab.active {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+/* 각 탭 콘텐츠 */
+.auth-tab-content {
+  margin-top: 8px;
+}
+
+/* 기본 form 스타일 */
+.form-group {
+  margin-bottom: 12px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.form-group label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #374151;
+}
+
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  outline: none;
+  box-sizing: border-box;
+  background-color: #ffffff;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.25);
+}
+
+/* 체크박스 그리드 */
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 6px;
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  font-size: 13px;
+  cursor: pointer;
+  background-color: #f9fafb;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.checkbox-item input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.checkbox-item:hover {
+  background-color: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+/* 버튼 */
+.btn-primary {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border: none;
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.05s ease;
+}
+
+.btn-primary:hover {
+  background: #1d4ed8;
+}
+
+.btn-primary:active {
+  transform: translateY(1px);
+}
+
+.btn-primary:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+/* 에러 메시지 */
+.form-error,
+.error {
+  min-height: 18px;
+  font-size: 12px;
+  color: #dc2626;
+  margin-top: 4px;
+}
+
+/* 로그인용 input 간격 */
+#loginForm input {
+  display: block;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+/* 모바일 대응 */
+@media (max-width: 600px) {
+  .auth-modal-box {
+    margin: 24px 12px;
+    padding: 20px 16px 16px;
+    border-radius: 12px;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .checkbox-grid {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+  #btnLogout {
+    display: none;
+  }
+}

--- a/src/main/webapp/resources/js/auth/login.js
+++ b/src/main/webapp/resources/js/auth/login.js
@@ -1,0 +1,421 @@
+// /resources/js/auth/login.js
+// 로그인/회원가입 모달 전용 스크립트
+
+import {
+  saveTokens,
+  clearTokens,
+  getAccessToken,
+  getTokenType,
+} from "../common/authTokenStorage.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupTabs();
+  setupLoginForm();
+  setupRegisterForm();
+  loadFormCodes();
+
+  //헤더 버튼 로그인/로그아웃 상태 반영
+  setupHeaderAuthButtons();
+
+  // 전역에서 모달 열고 닫을 수 있게
+  window.openAuthModal = openAuthModal;
+  window.closeAuthModal = closeAuthModal;
+});
+
+function setupHeaderAuthButtons() {
+  const loginBtn    = document.getElementById("btnOpenLogin");
+  const registerBtn = document.getElementById("btnOpenRegister");
+  const logoutBtn   = document.getElementById("btnLogout");
+
+  // 헤더가 없는 페이지면 그냥 리턴
+  if (!loginBtn || !logoutBtn) return;
+
+  const hasToken = !!getAccessToken();
+
+  if (hasToken) {
+    // ✅ 로그인 상태 → 로그아웃만 보이게
+    loginBtn.style.display = "none";
+    if (registerBtn) registerBtn.style.display = "none";
+    logoutBtn.style.display = "inline-block";
+  } else {
+    // ✅ 비로그인 상태 → 로그인 / 회원가입 표시
+    loginBtn.style.display = "inline-block";
+    if (registerBtn) registerBtn.style.display = "inline-block";
+    logoutBtn.style.display = "none";
+  }
+
+  // ▶ 로그인 버튼: 로그인 탭을 열면서 모달 띄우기
+  loginBtn.onclick = () => {
+    openAuthModal();
+    const loginTabBtn = document.querySelector('.auth-tab[data-tab="login"]');
+    if (loginTabBtn) loginTabBtn.click();
+  };
+
+  // ▶ 회원가입 버튼: 회원가입 탭을 열면서 모달 띄우기
+  if (registerBtn) {
+    registerBtn.onclick = () => {
+      openAuthModal();
+      const regTabBtn = document.querySelector(
+        '.auth-tab[data-tab="register"]'
+      );
+      if (regTabBtn) regTabBtn.click();
+    };
+  }
+
+  // ▶ 로그아웃 버튼
+  logoutBtn.onclick = async () => {
+    try {
+      const accessToken = getAccessToken();
+      const tokenType = getTokenType() || "Bearer";
+
+      if (accessToken) {
+        await fetch("/api/auth/logout", {
+          method: "POST",
+          headers: {
+            Authorization: `${tokenType} ${accessToken}`,
+          },
+        });
+      }
+    } catch (err) {
+      console.error("logout error:", err);
+    } finally {
+      // 어쨌든 토큰은 지우고 새로고침
+      clearTokens();
+      location.reload();
+    }
+  };
+}
+
+
+/* =====================
+ *  모달 열기/닫기
+ * ===================== */
+function openAuthModal() {
+  const modal = document.getElementById("authModal");
+  if (!modal) return;
+  modal.classList.remove("hidden");
+}
+
+function closeAuthModal() {
+  const modal = document.getElementById("authModal");
+  if (!modal) return;
+  modal.classList.add("hidden");
+}
+
+/* =====================
+ *  탭 전환 (로그인 / 회원가입)
+ * ===================== */
+function setupTabs() {
+  const tabs = document.querySelectorAll(".auth-tab");
+  const loginTab = document.getElementById("loginTab");
+  const registerTab = document.getElementById("registerTab");
+
+  if (!tabs || !loginTab || !registerTab) return;
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      tabs.forEach((t) => t.classList.remove("active"));
+      tab.classList.add("active");
+
+      const target = tab.dataset.tab;
+      if (target === "login") {
+        loginTab.classList.remove("hidden");
+        registerTab.classList.add("hidden");
+      } else {
+        loginTab.classList.add("hidden");
+        registerTab.classList.remove("hidden");
+      }
+    });
+  });
+}
+
+/* =====================
+ *  로그인 처리
+ * ===================== */
+function setupLoginForm() {
+  const loginForm = document.getElementById("loginForm");
+  if (!loginForm) return;
+
+  const loginEmail = document.getElementById("loginEmail");
+  const loginPassword = document.getElementById("loginPassword");
+  const loginError = document.getElementById("loginError");
+
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    loginError.textContent = "";
+
+    const email = loginEmail.value.trim();
+    const password = loginPassword.value;
+
+    if (!email || !password) {
+      loginError.textContent = "이메일과 비밀번호를 입력해주세요.";
+      return;
+    }
+
+    try {
+      // 기존 토큰 제거
+      clearTokens();
+
+      const res = await fetch("/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!res.ok) {
+        let message = "로그인에 실패했습니다. 이메일/비밀번호를 확인해주세요.";
+        try {
+          const errBody = await res.json();
+          if (errBody && errBody.message) {
+            message = errBody.message;
+          }
+        } catch (_) {}
+        loginError.textContent = message;
+        return;
+      }
+
+      const data = await res.json();
+      const {
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        token_type: tokenType,
+      } = data;
+
+      if (!accessToken || !refreshToken) {
+        loginError.textContent = "서버에서 토큰 정보를 받지 못했습니다.";
+        console.error("Login response:", data);
+        return;
+      }
+
+      // saveTokens가 객체를 받는지 / 개별 인자를 받는지 모를 때 안전하게 처리
+      if (saveTokens.length >= 2) {
+        // (accessToken, refreshToken, tokenType) 방식
+        saveTokens(accessToken, refreshToken, tokenType || "Bearer");
+      } else {
+        // ({ accessToken, refreshToken, tokenType }) 방식
+        saveTokens({
+          accessToken,
+          refreshToken,
+          tokenType: tokenType || "Bearer",
+        });
+      }
+
+      closeAuthModal();
+      // 로그인 후 원하는 곳으로 이동
+      // location.href = "/main";
+      location.reload();
+    } catch (err) {
+      console.error("Login error:", err);
+      loginError.textContent = "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+    }
+  });
+}
+
+/* =====================
+ *  회원가입 처리
+ * ===================== */
+function setupRegisterForm() {
+  const registerForm = document.getElementById("registerForm");
+  if (!registerForm) return;
+
+  registerForm.addEventListener("submit", handleRegisterSubmit);
+}
+
+async function handleRegisterSubmit(e) {
+  e.preventDefault();
+
+  const name = document.getElementById("regName").value.trim();
+  const email = document.getElementById("regEmail").value.trim();
+  const phone = document.getElementById("regPhone").value.trim();
+  const password = document.getElementById("regPassword").value;
+  const confirm = document.getElementById("regConfirm").value;
+  const smoking = document.getElementById("regSmoking").value;       // NON_SMOKER | SMOKER
+  const drinking = document.getElementById("regDrinking").value;     // NONE | SOCIAL | OFTEN
+  const sleepTime = document.getElementById("regSleepTime").value || null;
+  const workTypeSelect = document.getElementById("regWorkType");
+  const workTypeRaw = workTypeSelect.value;
+  const mbti = document.getElementById("regMbti").value || null;
+  const photoUrl = document.getElementById("regPhoto").value.trim();
+  const registerError = document.getElementById("registerError");
+
+  registerError.textContent = "";
+
+  if (password !== confirm) {
+    registerError.textContent = "비밀번호가 일치하지 않습니다.";
+    return;
+  }
+  // 🔥 workTypeId 필수 체크 (DTO @NotNull)
+  if (!workTypeRaw) {
+    registerError.textContent = "직업/라이프스타일을 선택해주세요.";
+    return;
+  }
+  const workTypeId = Number(workTypeRaw);
+
+  // 체크된 취미/선호/반려동물 ID 수집
+  const hobbyIds = Array.from(
+    document.querySelectorAll(".hobby-checkbox:checked")
+  ).map((el) => Number(el.value));
+
+  const preferenceIds = Array.from(
+    document.querySelectorAll(".preference-checkbox:checked")
+  ).map((el) => Number(el.value));
+
+  const petIds = Array.from(
+    document.querySelectorAll(".pet-checkbox:checked")
+  ).map((el) => Number(el.value));
+
+  // ⚠️ 여기부터는 백엔드 SignUpRequest 필드 이름(camelCase)에 맞춘다
+  const payload = {
+    email,
+    password,
+    name,
+    phone,
+
+    // 자바: photoUrl  → JSON: photo_url
+    photo_url: photoUrl || null,
+
+    // 자바: sleepTime → JSON: sleep_time
+    sleep_time: sleepTime,     // String
+    // 자바: workTypeId → JSON: work_type_id
+    work_type_id: workTypeId,  // Long or null
+    smoking,                   // MemberSmokingEnum (NON_SMOKER / SMOKER)
+    drinking,                  // MemberDrinkingEnum (NONE / SOCIAL / OFTEN)
+    mbti,                      // String or null
+
+    // 자바: hobbyIds → JSON: hobby_ids
+    hobby_ids: hobbyIds,
+    preference_ids: preferenceIds,
+    pet_ids: petIds,
+  };
+
+  try {
+    const res = await fetch("/api/auth/signup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      let message = "회원가입에 실패했습니다.";
+      try {
+        const errBody = await res.json();
+        if (errBody && errBody.message) {
+          message = errBody.message;
+        }
+      } catch (_) {}
+      registerError.textContent = message;
+      return;
+    }
+
+    alert("회원가입이 완료되었습니다. 로그인 해주세요.");
+
+    // 탭을 로그인 쪽으로 이동
+    const loginTabBtn = document.querySelector('.auth-tab[data-tab="login"]');
+    if (loginTabBtn) loginTabBtn.click();
+  } catch (err) {
+    console.error("Register error:", err);
+    registerError.textContent = "서버 오류가 발생했습니다.";
+  }
+}
+
+/* =====================
+ *  코드(직업/취미/선호/반려동물) 로딩
+ * ===================== */
+async function loadFormCodes() {
+  const workTypeSelect = document.getElementById("regWorkType");
+  const hobbyContainer = document.getElementById("hobbyCheckboxList");
+  const prefContainer = document.getElementById("preferenceCheckboxList");
+  const petContainer = document.getElementById("petCheckboxList");
+
+  if (!workTypeSelect || !hobbyContainer || !prefContainer || !petContainer) {
+    return;
+  }
+
+  try {
+    const res = await fetch("/api/members/form-codes");
+    if (!res.ok) {
+      console.error("form-codes load failed");
+      return;
+    }
+
+    const data = await res.json();
+    // snake_case → JS 변수명으로 매핑
+    const {
+      work_types: workTypes,
+      hobbies,
+      preferences,
+      pets,
+    } = data;
+    // 직업/라이프스타일
+    if (Array.isArray(workTypes)) {
+      workTypes.forEach((wt) => {
+        const opt = document.createElement("option");
+        opt.value = wt.work_type_id;
+        opt.textContent = wt.work_type_name;
+        workTypeSelect.appendChild(opt);
+      });
+    }
+
+    // 취미
+    if (Array.isArray(hobbies)) {
+      hobbies.forEach((hobby) => {
+        const label = document.createElement("label");
+        label.classList.add("checkbox-item");
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.classList.add("hobby-checkbox");
+        checkbox.value = hobby.hobby_id;
+
+        const span = document.createElement("span");
+        span.textContent = hobby.hobby_name;
+
+        label.appendChild(checkbox);
+        label.appendChild(span);
+        hobbyContainer.appendChild(label);
+      });
+    }
+
+    // 생활 선호
+    if (Array.isArray(preferences)) {
+      preferences.forEach((pref) => {
+        const label = document.createElement("label");
+        label.classList.add("checkbox-item");
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.classList.add("preference-checkbox");
+        checkbox.value = pref.preference_id;
+
+        const span = document.createElement("span");
+        span.textContent = pref.preference_name;
+
+        label.appendChild(checkbox);
+        label.appendChild(span);
+        prefContainer.appendChild(label);
+      });
+    }
+
+    // 반려동물
+    if (Array.isArray(pets)) {
+      pets.forEach((pet) => {
+        const label = document.createElement("label");
+        label.classList.add("checkbox-item");
+
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.classList.add("pet-checkbox");
+        checkbox.value = pet.pet_id;
+
+        const span = document.createElement("span");
+        span.textContent = pet.pet_name;
+
+        label.appendChild(checkbox);
+        label.appendChild(span);
+        petContainer.appendChild(label);
+      });
+    }
+  } catch (err) {
+    console.error("loadFormCodes error:", err);
+  }
+}

--- a/src/main/webapp/resources/js/common/apiClient.js
+++ b/src/main/webapp/resources/js/common/apiClient.js
@@ -71,9 +71,9 @@ export async function apiRequest(input, init = {}) {
 
   // 응답 필드 이름은 서버 snake_case 기준
   saveTokens({
-    accessToken: refreshData.accessToken,
-    refreshToken: refreshData.refreshToken,
-    tokenType: refreshData.tokenType,
+    access_token: refreshData.accessToken,
+    refresh_token: refreshData.refreshToken,
+    token_type: refreshData.tokenType,
   });
 
   // 🔁 새 AccessToken으로 원래 요청 다시 한번 시도


### PR DESCRIPTION
## 작업 내용

- 로그인/회원가입 모달 UI 구현 (`login.jsp`, `header.jsp`, `login.css`, `login.js`)
  - 헤더에서 "로그인" 버튼 클릭 시 모달 오픈
  - 탭 전환으로 로그인 / 회원가입 분리

- JWT 인증 연동
  - `/api/auth/signup` 회원가입 구현
  - `/api/auth/login` 로그인 구현
  - `/api/auth/refresh` 리프레시 토큰으로 액세스 토큰 재발급
  - `/api/auth/logout` 로그아웃 시 Refresh Token 삭제
  - `authTokenStorage.js` + `apiClient.js` 를 통해 토큰 저장 및 자동 헤더 설정

- 회원 코드 조회 API 추가
  - `/api/members/form-codes`에서 직업/취미/선호/반려동물 코드 한 번에 조회
  - `FormCodesResponse`, `HobbyResponse`, `PreferenceResponse`, `PetResponse` 추가
  - Hobby/Preference/Pet/WorkType 엔티티 및 MyBatis 매퍼/레포지토리 추가

- 시큐리티 설정 수정
  - `/auth/**`, `/api/auth/**`, 정적 리소스(`/resources/**`) permitAll
  - 기타 API는 추후 인증 적용 가능하도록 기본 구조 정리

---

## 테스트 방법

1. 메인 페이지 접속
   - 상단 헤더에서 "로그인" 버튼 클릭 시 모달이 열리는지 확인

2. 회원가입
   - 회원가입 탭에서 필수 값 입력 후 회원가입 요청
   - DB `members`, `member_hobby`, `member_preference`, `member_pet` 테이블에 데이터가 정상 저장되는지 확인

3. 로그인
   - 회원가입한 계정으로 로그인
   - `localStorage` 또는 `sessionStorage`에 accessToken, refreshToken이 저장되는지 확인
   - 새로고침 후에도 로그인 상태 유지되는지 확인

4. form-codes
   - 브라우저 개발자도구에서 `/api/members/form-codes` 요청 확인
   - 응답으로 workTypes, hobbies, preferences, pets 데이터가 내려오고,
     회원가입 모달에서 셀렉트/체크박스가 정상 렌더링되는지 확인

---

## 체크리스트

- [x] 빌드 성공
- [x] 신규 회원가입 및 로그인 정상 동작
- [x] DB 코드(work_types, hobbies, preferences, pets) 조회 정상 동작
- [x] 기존 기능에 영향 없는지 간단한 수동 테스트 완료
