### PR TITLE
feat: 회원 프로필 조회·수정 및 탈퇴 시 연관 데이터 정리 로직 추가

### DIFF
--- a/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
@@ -13,6 +13,9 @@ import com.roommate.domain.auth.repository.TokenRefreshRepository;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberEntity;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
+import com.roommate.domain.member.repository.MemberHobbyRepository;
+import com.roommate.domain.member.repository.MemberPetRepository;
+import com.roommate.domain.member.repository.MemberPreferenceRepository;
 import com.roommate.domain.member.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +36,23 @@ public class AuthServiceImpl implements AuthService {
     private final JwtUtil jwtUtil;
     private final TokenRefreshRepository tokenRefreshRepository;
 
+    private final MemberHobbyRepository memberHobbyRepository;
+    private final MemberPreferenceRepository memberPreferenceRepository;
+    private final MemberPetRepository memberPetRepository;
+
+
     @Override
     public void validateEmailDuplication(String email) {
-        if (memberRepository.findByEmail(email).isPresent()) {
+        memberRepository.findByEmail(email).ifPresent(member -> {
+            // 왜 이렇게 썼는지:
+            // - soft delete 구조에서도 email UNIQUE 제약이 있기 때문에
+            //   deleted = 1 이라도 동일 이메일로 재가입을 허용하지 않는다.
+            if (member.getDeleted() == 1) {
+                // 이미 탈퇴한 이메일로 재가입 시도
+                throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+            }
             throw new ApiException(ErrorCode.DUPLICATE_EMAIL);
-        }
+        });
     }
 
     @Override
@@ -114,22 +129,16 @@ public class AuthServiceImpl implements AuthService {
         memberRepository.save(memberEntity);
         Long memberId = memberEntity.getMemberId();
 
-        if (signUpRequest.getHobbyIds() != null) {
-            for (Long hobbyId : signUpRequest.getHobbyIds()) {
-                memberRepository.insertMemberHobby(memberId, hobbyId);
-            }
+        if (signUpRequest.getHobbyIds() != null && !signUpRequest.getHobbyIds().isEmpty()) {
+            memberHobbyRepository.insertMemberHobbies(memberId, signUpRequest.getHobbyIds());
         }
 
-        if (signUpRequest.getPreferenceIds() != null) {
-            for (Long preferenceId : signUpRequest.getPreferenceIds()) {
-                memberRepository.insertMemberPreference(memberId, preferenceId);
-            }
+        if (signUpRequest.getPreferenceIds() != null && !signUpRequest.getPreferenceIds().isEmpty()) {
+            memberPreferenceRepository.insertMemberPreferences(memberId, signUpRequest.getPreferenceIds());
         }
 
-        if (signUpRequest.getPetIds() != null) {
-            for (Long petId : signUpRequest.getPetIds()) {
-                memberRepository.insertMemberPet(memberId, petId);
-            }
+        if (signUpRequest.getPetIds() != null && !signUpRequest.getPetIds().isEmpty()) {
+            memberPetRepository.insertMemberPets(memberId, signUpRequest.getPetIds());
         }
 
         SignUpResponse response = toSignUpResponse(memberEntity);
@@ -139,10 +148,19 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public LoginResponse login(LoginRequest loginRequest) {
         MemberEntity memberEntity = memberRepository.findByEmail(loginRequest.getEmail()).orElseThrow(() -> new ApiException(ErrorCode.INVALID_EMAIL_FORMAT));
+
+        if (memberEntity.getDeleted() == 1) {
+            // 왜 이렇게 썼는지:
+            // - soft delete 된 회원은 로그인 자체를 막아서
+            //   탈퇴 후 토큰 발급/서비스 이용을 차단하기 위함.
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
+
         validatePassword(loginRequest.getPassword(), memberEntity.getPassword());
         String accessToken = jwtUtil.createAccessToken(memberEntity.getMemberId(), memberEntity.getRole());
         String refreshToken = jwtUtil.createRefreshToken(memberEntity.getMemberId(), memberEntity.getRole());
         saveOrUpdateRefreshToken(memberEntity, refreshToken);
+
         LoginResponse loginResponse = toLoginResponse(memberEntity, accessToken, refreshToken);
         return loginResponse;
     }
@@ -198,6 +216,9 @@ public class AuthServiceImpl implements AuthService {
          */
         Long memberId = jwtUtil.getMemberIdFromRefreshToken(refreshToken);
         MemberEntity memberEntity = memberRepository.findById(memberId).orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+        if (memberEntity.getDeleted() == 1) {
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
         /**
          * 3) DB에 저장된 Refresh Token 검증
          *    - 서버는 Refresh Token 원본을 저장하지 않고 Bcrypt 해시값만 저장한다.

--- a/src/main/java/com/roommate/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/roommate/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.roommate.domain.chat.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ChatMessageRepository {
+}

--- a/src/main/java/com/roommate/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/roommate/domain/chat/repository/ChatRepository.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.chat.repository;
-
-public interface ChatRepository {
-}

--- a/src/main/java/com/roommate/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/roommate/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.roommate.domain.chat.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ChatRoomRepository {
+    void markDeletedByMember(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/roommate/domain/chat/service/ChatSerivcceImp.java
+++ b/src/main/java/com/roommate/domain/chat/service/ChatSerivcceImp.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.chat.service;
-
-public class ChatSerivcceImp implements ChatService{
-}

--- a/src/main/java/com/roommate/domain/chat/service/ChatServiceImp.java
+++ b/src/main/java/com/roommate/domain/chat/service/ChatServiceImp.java
@@ -1,0 +1,4 @@
+package com.roommate.domain.chat.service;
+
+public class ChatServiceImp implements ChatService{
+}

--- a/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
@@ -1,6 +1,7 @@
 package com.roommate.domain.member.controller;
 
 import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
@@ -8,9 +9,7 @@ import com.roommate.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -25,13 +24,13 @@ public class MemberRestController {
      * 일 종류에 전체를 조회합니다
      */
     @GetMapping("/work-types")
-    public ResponseEntity<List<WorkTypeResponse>> getAllWorkTypes(){
+    public ResponseEntity<List<WorkTypeResponse>> getAllWorkTypes() {
         List<WorkTypeResponse> workTypes = memberService.getFormCodes().getWorkTypes();
         return ResponseEntity.ok(workTypes);
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails){
+    public ResponseEntity<MemberResponse> getMemberInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         MemberResponse memberResponse = memberService.memberInfo(userDetails.getMemberId());
         return ResponseEntity.ok(memberResponse);
     }
@@ -39,10 +38,25 @@ public class MemberRestController {
     /**
      * 회원가입 / 프로필 수정 화면에서 사용하는
      * 공통 코드(직업, 취미, 생활 선호, 반려동물)를 한 번에 조회합니다.
-     *
      */
     @GetMapping("/form-codes")
     public ResponseEntity<FormCodesResponse> getFormCodes() {
         return ResponseEntity.ok(memberService.getFormCodes());
+    }
+
+    /**
+     * 내 프로필 수정
+     */
+    @PutMapping("/me")
+    public ResponseEntity<MemberResponse> updateMemberProfile(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody MemberProfileUpdateRequest MemberProfileUpdateRequest) {
+        MemberResponse updated = memberService.updateMemberProfile(userDetails.getMemberId(), MemberProfileUpdateRequest);
+        // 200 OK 로 반환해도 되지만, Location을 주고 싶으면 created 형태도 가능.
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        memberService.deleteMember(userDetails.getMemberId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/roommate/domain/member/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/roommate/domain/member/dto/request/MemberProfileUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.roommate.domain.member.dto.request;
+
+import com.roommate.domain.member.entity.MemberDrinkingEnum;
+import com.roommate.domain.member.entity.MemberSmokingEnum;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MemberProfileUpdateRequest {
+    private String name;
+    private String phone;
+    private String photoUrl;
+
+    private Long workTypeId;
+    private String sleepTime;
+
+    private MemberSmokingEnum smoking;
+    private MemberDrinkingEnum drinking;
+    private String mbti;
+
+    private List<Long> hobbyIds;
+    private List<Long> preferenceIds;
+    private List<Long> petIds;
+}

--- a/src/main/java/com/roommate/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/MemberResponse.java
@@ -5,8 +5,12 @@ import com.roommate.domain.member.entity.MemberRoleEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class MemberResponse {
+    private Long memberId;
+    private Long workTypeId;
     private String workTypeName;
     private String email;
     private String name;
@@ -17,4 +21,9 @@ public class MemberResponse {
     private MemberDrinkingEnum drinking;
     private String mbti;
     private MemberRoleEnum memberRoleEnum;
+
+    // 프로필 상세에 필요한 목록들
+    private List<HobbyResponse> hobbies;
+    private List<PreferenceResponse> preferences;
+    private List<PetResponse> pets;
 }

--- a/src/main/java/com/roommate/domain/member/repository/HobbyRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/HobbyRepository.java
@@ -2,10 +2,14 @@ package com.roommate.domain.member.repository;
 
 import com.roommate.domain.member.entity.HobbyEntity;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface HobbyRepository {
+
     List<HobbyEntity> findAll();
+
+    List<HobbyEntity> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/roommate/domain/member/repository/MemberHobbyRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberHobbyRepository.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.member.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MemberHobbyRepository {
+
+    void deleteByMemberId(@Param("memberId") Long memberId);
+
+    void insertMemberHobbies(@Param("memberId") Long memberId, @Param("hobbyIds") List<Long> hobbyIds);
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberPetRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberPetRepository.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.member.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MemberPetRepository {
+
+    void deleteByMemberId(@Param("memberId") Long memberId);
+
+    void insertMemberPets(@Param("memberId") Long memberId, @Param("petIds") List<Long> petIds);
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberPreferenceRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberPreferenceRepository.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.member.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface MemberPreferenceRepository {
+
+    void deleteByMemberId(@Param("memberId") Long memberId);
+
+    void insertMemberPreferences(@Param("memberId") Long memberId, @Param("preferenceIds") List<Long> preferenceIds);
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -23,4 +23,6 @@ public interface MemberRepository {
 
     void insertMemberPet(@Param("memberId") Long memberId, @Param("petId") Long petId);
 
+    void softDeleteMember(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/roommate/domain/member/repository/PetRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/PetRepository.java
@@ -2,10 +2,14 @@ package com.roommate.domain.member.repository;
 
 import com.roommate.domain.member.entity.PetEntity;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface PetRepository {
+
     List<PetEntity> findAll();
+
+    List<PetEntity> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/roommate/domain/member/repository/PreferenceRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/PreferenceRepository.java
@@ -2,10 +2,14 @@ package com.roommate.domain.member.repository;
 
 import com.roommate.domain.member.entity.PreferenceEntity;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface PreferenceRepository {
+
     List<PreferenceEntity> findAll();
+
+    List<PreferenceEntity> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberService.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.roommate.domain.member.service;
 
 import java.util.List;
 
+import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
@@ -13,8 +14,9 @@ public interface MemberService {
 	 */
 	public MemberResponse memberInfo(Long memberId);
 
-	/**
-	 *
-	 */
+	public MemberResponse updateMemberProfile(Long memberId, MemberProfileUpdateRequest request);
+
+	void deleteMember(Long memberId);
+
 	public FormCodesResponse getFormCodes();
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
@@ -1,15 +1,23 @@
 package com.roommate.domain.member.service;
 
-import java.util.List;
-
 import com.roommate.common.exception.ApiException;
 import com.roommate.common.exception.ErrorCode;
+import com.roommate.domain.auth.repository.TokenRefreshRepository;
+import com.roommate.domain.chat.repository.ChatMessageRepository;
+import com.roommate.domain.chat.repository.ChatRoomRepository;
+import com.roommate.domain.favorite.repository.FavoriteRepository;
+import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.*;
 import com.roommate.domain.member.entity.*;
 import com.roommate.domain.member.repository.*;
+import com.roommate.domain.notification.repository.NotificationRepository;
+import com.roommate.domain.room.repository.RoomRepository;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +28,16 @@ public class MemberServiceImpl implements MemberService {
     private final HobbyRepository hobbyRepository;
     private final PreferenceRepository preferenceRepository;
     private final PetRepository petRepository;
+
+    private final MemberHobbyRepository memberHobbyRepository;
+    private final MemberPreferenceRepository memberPreferenceRepository;
+    private final MemberPetRepository memberPetRepository;
+
+    private final FavoriteRepository favoriteRepository;
+    private final NotificationRepository notificationRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final RoomRepository roomRepository;
+    private final TokenRefreshRepository tokenRefreshRepository;
 
     private WorkTypeResponse toWorkTypeResponse(WorkTypeEntity workTypeEntity) {
         WorkTypeResponse workTypeResponse = new WorkTypeResponse();
@@ -49,18 +67,25 @@ public class MemberServiceImpl implements MemberService {
         return petResponse;
     }
 
-    private MemberResponse toMemberResponse(MemberEntity memberEntity, String workTypeName) {
+    private MemberResponse toMemberResponse(MemberEntity memberEntity, WorkTypeEntity workTypeEntity, List<HobbyEntity> hobbyEntities, List<PreferenceEntity> preferenceEntities, List<PetEntity> petEntities) {
         MemberResponse memberResponse = new MemberResponse();
-        memberResponse.setWorkTypeName(workTypeName);
+        memberResponse.setMemberId(memberEntity.getMemberId());
         memberResponse.setEmail(memberEntity.getEmail());
         memberResponse.setName(memberEntity.getName());
         memberResponse.setPhone(memberEntity.getPhone());
         memberResponse.setPhotoUrl(memberEntity.getPhotoUrl());
+        if (workTypeEntity != null) {
+            memberResponse.setWorkTypeId(workTypeEntity.getWorkTypeId());
+            memberResponse.setWorkTypeName(workTypeEntity.getWorkTypeName());
+        }
         memberResponse.setSleepTime(memberEntity.getSleepTime());
         memberResponse.setSmoking(memberEntity.getSmoking() != null ? memberEntity.getSmoking() : MemberSmokingEnum.NON_SMOKER);
         memberResponse.setDrinking(memberEntity.getDrinking() != null ? memberEntity.getDrinking() : MemberDrinkingEnum.NONE);
         memberResponse.setMbti(memberEntity.getMbti());
         memberResponse.setMemberRoleEnum(memberEntity.getRole());
+        memberResponse.setHobbies(hobbyEntities.stream().map(this::toHobbyResponse).toList());
+        memberResponse.setPreferences(preferenceEntities.stream().map(this::toPreferenceResponse).toList());
+        memberResponse.setPets(petEntities.stream().map(this::toPetResponse).toList());
         return memberResponse;
     }
 
@@ -77,8 +102,150 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberResponse memberInfo(Long memberId) {
         MemberEntity memberEntity = memberRepository.findById(memberId).orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
-        WorkTypeEntity workTypeEntity = workTypeRepository.findById(memberEntity.getWorkTypeId()).orElseThrow(() -> new ApiException(ErrorCode.WORK_TYPE_NOT_FOUND));
-        MemberResponse memberResponse = toMemberResponse(memberEntity, workTypeEntity.getWorkTypeName());
+        if (memberEntity.getDeleted() == 1) {
+            // 왜 이렇게 썼는지:
+            // - 탈퇴한 사용자가 토큰을 들고 있을 수도 있으므로,
+            //   deleted 플래그가 1이면 로그인 불가 상태로 취급.
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
+        WorkTypeEntity workTypeEntity = null;
+        if (memberEntity.getWorkTypeId() != null) {
+            workTypeEntity = workTypeRepository.findById(memberEntity.getWorkTypeId()).orElse(null); // 없다고 해서 에러로 처리하진 않음
+        }
+        List<HobbyEntity> hobbyEntities = hobbyRepository.findByMemberId(memberId);
+        List<PreferenceEntity> preferenceEntities = preferenceRepository.findByMemberId(memberId);
+        List<PetEntity> petEntities = petRepository.findByMemberId(memberId);
+        MemberResponse memberResponse = toMemberResponse(memberEntity, workTypeEntity, hobbyEntities, preferenceEntities, petEntities);
         return memberResponse;
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse updateMemberProfile(Long memberId, MemberProfileUpdateRequest memberProfileUpdateRequest) {
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (memberEntity.getDeleted() == 1) {
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
+
+        // 1) 단일 필드 업데이트
+        // 왜 이렇게 썼는지:
+        // - null 체크 후 값이 있을 때만 업데이트 해서
+        //   부분 업데이트(PATCH와 같은 효과)를 허용하기 위함.
+        if (memberProfileUpdateRequest.getName() != null) {
+            memberEntity.setName(memberProfileUpdateRequest.getName());
+        }
+        if (memberProfileUpdateRequest.getPhone() != null) {
+            memberEntity.setPhone(memberProfileUpdateRequest.getPhone());
+        }
+        if (memberProfileUpdateRequest.getPhotoUrl() != null) {
+            memberEntity.setPhotoUrl(memberProfileUpdateRequest.getPhotoUrl());
+        }
+        if (memberProfileUpdateRequest.getWorkTypeId() != null) {
+            memberEntity.setWorkTypeId(memberProfileUpdateRequest.getWorkTypeId());
+        }
+        if (memberProfileUpdateRequest.getSleepTime() != null) {
+            memberEntity.setSleepTime(memberProfileUpdateRequest.getSleepTime());
+        }
+        if (memberProfileUpdateRequest.getSmoking() != null) {
+            memberEntity.setSmoking(memberProfileUpdateRequest.getSmoking());
+        }
+        if (memberProfileUpdateRequest.getDrinking() != null) {
+            memberEntity.setDrinking(memberProfileUpdateRequest.getDrinking());
+        }
+        if (memberProfileUpdateRequest.getMbti() != null) {
+            memberEntity.setMbti(memberProfileUpdateRequest.getMbti());
+        }
+
+        memberRepository.updateMember(memberEntity);
+
+        // 2) N:N 관계 테이블 갱신
+        //    가장 단순하고 안전한 패턴: delete all → insert all
+        if (memberProfileUpdateRequest.getHobbyIds() != null) {
+            memberHobbyRepository.deleteByMemberId(memberId);
+            if (!memberProfileUpdateRequest.getHobbyIds().isEmpty()) {
+                memberHobbyRepository.insertMemberHobbies(memberId, memberProfileUpdateRequest.getHobbyIds());
+            }
+        }
+
+        if (memberProfileUpdateRequest.getPreferenceIds() != null) {
+            memberPreferenceRepository.deleteByMemberId(memberId);
+            if (!memberProfileUpdateRequest.getPreferenceIds().isEmpty()) {
+                memberPreferenceRepository.insertMemberPreferences(memberId, memberProfileUpdateRequest.getPreferenceIds());
+            }
+        }
+
+        if (memberProfileUpdateRequest.getPetIds() != null) {
+            memberPetRepository.deleteByMemberId(memberId);
+            if (!memberProfileUpdateRequest.getPetIds().isEmpty()) {
+                memberPetRepository.insertMemberPets(memberId, memberProfileUpdateRequest.getPetIds());
+            }
+        }
+
+        // 3) 응답용 데이터 재조회
+        WorkTypeEntity workTypeEntity = null;
+        if (memberEntity.getWorkTypeId() != null) {
+            workTypeEntity = workTypeRepository.findById(memberEntity.getWorkTypeId())
+                    .orElse(null);
+        }
+
+        List<HobbyEntity> hobbyEntities = hobbyRepository.findByMemberId(memberId);
+        List<PreferenceEntity> preferenceEntities = preferenceRepository.findByMemberId(memberId);
+        List<PetEntity> petEntities = petRepository.findByMemberId(memberId);
+
+        return toMemberResponse(memberEntity, workTypeEntity, hobbyEntities, preferenceEntities, petEntities);
+    }
+
+    /**
+     * 회원 탈퇴 처리
+     *
+     * 왜 이렇게 썼는지:
+     * - 실제 members row를 삭제하지 않고 deleted 플래그로 관리(soft delete)해서
+     *   FK 제약, 채팅/방 이력, 통계 데이터를 보존하기 위함.
+     * - 연관 테이블은 도메인 정책에 맞게 정리하고,
+     *   채팅 메시지는 남기되 채팅방은 "탈퇴한 회원 기준으로만" 나가기 처리한다.
+     */
+    @Override
+    @Transactional
+    public void deleteMember(Long memberId) {
+        MemberEntity memberEntity = memberRepository.findById(memberId).orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (memberEntity.getDeleted() == 1) {
+            return;
+        }
+        // 0) Refresh Token 삭제 (로그아웃 효과)
+        // - 탈퇴 후 더 이상 토큰 재발급/인증이 되지 않도록
+        //   해당 회원의 refresh token 레코드를 먼저 제거한다.
+        tokenRefreshRepository.deleteByMemberId(memberId);
+
+        // 1) N:N 관계(member_* 조인 테이블) 관계 제거
+        // - 회원과 취미/선호/반려동물 관계를 모두 끊어서
+        //   추후 조회 시 더 이상 이 회원의 취향 정보가 보이지 않도록 한다.
+        memberPetRepository.deleteByMemberId(memberId);
+        memberPreferenceRepository.deleteByMemberId(memberId);
+        memberHobbyRepository.deleteByMemberId(memberId);
+
+        // 2) 찜(favorites) 삭제
+        // - 내가 찜해둔 방 목록은 탈퇴 후 의미가 없으므로 전부 삭제.
+        favoriteRepository.deleteByMemberId(memberId);
+
+        // 3) 알림(notifications) 삭제
+        // - 나에게 온 알림들도 더 이상 사용할 수 없으므로 한 번에 삭제.
+        notificationRepository.deleteByMemberId(memberId);
+
+        // 4) 채팅방 정리
+        // - 채팅 메시지(chat_messages)는 기록 보존을 위해 그대로 두고,
+        //   채팅방(chat_rooms)은 "탈퇴한 회원 기준으로만" 나가기 처리한다.
+        // - 상대방 입장에서는 기존 대화방과 메시지 이력이 그대로 남는다.
+        chatRoomRepository.markDeletedByMember(memberId);
+
+        // 5) 내가 올린 방(rooms) 정리 - 논리 삭제
+        // - 방 이력을 완전히 지우기보다는,
+        //   status = CLOSED, deleted = 1 로 더 이상 노출되지 않게 처리한다.
+        roomRepository.closeAndDeleteByMemberId(memberId);
+
+        // 6) 최종적으로 members.deleted = 1 로 soft delete
+        memberRepository.softDeleteMember(memberId);
     }
 }

--- a/src/main/java/com/roommate/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/roommate/domain/notification/repository/NotificationRepository.java
@@ -1,9 +1,9 @@
-package com.roommate.domain.favorite.repository;
+package com.roommate.domain.notification.repository;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 @Mapper
-public interface FavoriteRepository {
+public interface NotificationRepository {
     void deleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/roommate/domain/notification/repository/NotificationRepsitory.java
+++ b/src/main/java/com/roommate/domain/notification/repository/NotificationRepsitory.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.notification.repository;
-
-public interface NotificationRepsitory {
-}

--- a/src/main/java/com/roommate/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/roommate/domain/room/repository/RoomRepository.java
@@ -1,4 +1,9 @@
 package com.roommate.domain.room.repository;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
 public interface RoomRepository {
+    void closeAndDeleteByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/resources/mapper/chat/chat_room.xml
+++ b/src/main/resources/mapper/chat/chat_room.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.chat.repository.ChatRoomRepository">
+
+    <update id="markDeletedByMember" parameterType="long">
+        UPDATE chat_rooms
+        SET
+        deleted_by_owner = CASE
+        WHEN owner_id = #{memberId} THEN 1
+        ELSE deleted_by_owner
+        END,
+        deleted_by_partner = CASE
+        WHEN partner_id = #{memberId} THEN 1
+        ELSE deleted_by_partner
+        END
+        WHERE owner_id = #{memberId}
+        OR partner_id = #{memberId}
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/favorite/favorite.xml
+++ b/src/main/resources/mapper/favorite/favorite.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.favorite.repository.FavoriteRepository">
+
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM favorites
+        WHERE member_id = #{memberId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/hobby/hobby.xml
+++ b/src/main/resources/mapper/hobby/hobby.xml
@@ -15,4 +15,14 @@
         ORDER BY hobby_name
     </select>
 
+    <!-- mapper/hobby/hobby.xml -->
+    <select id="findByMemberId" parameterType="long" resultType="com.roommate.domain.member.entity.HobbyEntity">
+        SELECT h.hobby_id,
+        h.hobby_name,
+        h.created_at
+        FROM hobbies h
+        JOIN member_hobbies mh ON h.hobby_id = mh.hobby_id
+        WHERE mh.member_id = #{memberId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/member/member.xml
+++ b/src/main/resources/mapper/member/member.xml
@@ -94,4 +94,10 @@
         WHERE
             member_id = #{memberId}
     </update>
+    <!-- resources/mapper/member/member.xml -->
+    <update id="softDeleteMember" parameterType="long">
+        UPDATE members
+        SET deleted = 1
+        WHERE member_id = #{memberId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/member/member_hobby.xml
+++ b/src/main/resources/mapper/member/member_hobby.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.MemberHobbyRepository">
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM member_hobbies WHERE member_id = #{memberId}
+    </delete>
+
+    <insert id="insertMemberHobbies">
+        INSERT INTO member_hobbies (member_id, hobby_id)
+        VALUES
+        <foreach collection="hobbyIds" item="hobbyId" separator=",">
+            (#{memberId}, #{hobbyId})
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/member/member_pet.xml
+++ b/src/main/resources/mapper/member/member_pet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.MemberPetRepository">
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM member_pets WHERE member_id = #{memberId}
+    </delete>
+
+    <insert id="insertMemberPets">
+        INSERT INTO member_pets (member_id, pet_id)
+        VALUES
+        <foreach collection="petIds" item="petId" separator=",">
+            (#{memberId}, #{petId})
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/member/member_preference.xml
+++ b/src/main/resources/mapper/member/member_preference.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.member.repository.MemberPreferenceRepository">
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM member_preferences WHERE member_id = #{memberId}
+    </delete>
+
+    <insert id="insertMemberPreferences">
+        INSERT INTO member_preferences (member_id, preference_id)
+        VALUES
+        <foreach collection="preferenceIds" item="preferenceId" separator=",">
+            (#{memberId}, #{preferenceId})
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/notification/notification.xml
+++ b/src/main/resources/mapper/notification/notification.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.notification.repository.NotificationRepository">
+
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM notifications
+        WHERE member_id = #{memberId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/pet/pet.xml
+++ b/src/main/resources/mapper/pet/pet.xml
@@ -14,5 +14,13 @@
         FROM pets
         ORDER BY pet_name
     </select>
+    <select id="findByMemberId" parameterType="long" resultType="com.roommate.domain.member.entity.PetEntity">
+        SELECT p.pet_id,
+        p.pet_name,
+        p.created_at
+        FROM pets p
+        JOIN member_pets mp ON p.pet_id = mp.pet_id
+        WHERE mp.member_id = #{memberId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/preference/preference.xml
+++ b/src/main/resources/mapper/preference/preference.xml
@@ -13,4 +13,13 @@
         FROM preferences
         ORDER BY preference_name
     </select>
+    <select id="findByMemberId" parameterType="long" resultType="com.roommate.domain.member.entity.PreferenceEntity">
+        SELECT p.preference_id,
+        p.preference_name,
+        p.created_at
+        FROM preferences p
+        JOIN member_preferences mp ON p.preference_id = mp.preference_id
+        WHERE mp.member_id = #{memberId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/room/room.xml
+++ b/src/main/resources/mapper/room/room.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.room.repository.RoomRepository">
+    <update id="closeAndDeleteByMemberId" parameterType="long">
+        UPDATE rooms
+        SET status = 'CLOSED',
+        deleted = 1
+        WHERE member_id = #{memberId}
+    </update>
+</mapper>


### PR DESCRIPTION
## ✅ 작업 개요
회원 도메인의 핵심 기능인 **내 프로필 조회/수정/탈퇴 API**를 구현하고,  
회원 탈퇴 시 발생하는 **연관 데이터 정리 로직을 일관된 정책으로 정비**했습니다.  
또한 JWT 인증 구조와 연동하여 **탈퇴 회원 접근 차단 로직까지 완성**했습니다.

---

## 🛠 주요 작업 내용

### 1. 회원 프로필 API 구현
- `GET /api/members/me`  
  → 내 프로필 조회 (직업, 취향, 반려동물, 생활습관 포함)
- `PUT /api/members/me`  
  → 프로필 수정 (닉네임, 전화번호, 사진, 직업, 수면시간, 흡연/음주, MBTI, 취향)
- `DELETE /api/members/me`  
  → 회원 탈퇴 (soft delete + 연관 데이터 정리)

---

### 2. 회원 탈퇴 정책 정비 (Soft Delete)
- `members.deleted = 1` 방식의 **논리 삭제 적용**
- Refresh Token 삭제 → 즉시 로그아웃 처리
- 탈퇴 후:
  - 로그인 불가
  - Access Token 재발급 불가
  - `/api/members/me` 접근 차단

---

### 3. 연관 테이블 정리 로직 구현
회원 탈퇴 시 다음 테이블 정리:

- ✅ N:N 관계 테이블  
  - `member_hobbies`
  - `member_preferences`
  - `member_pets`
- ✅ 찜(favorites) 삭제
- ✅ 알림(notifications) 삭제
- ✅ 채팅방(chat_rooms):  
  - 상대방 데이터 보존을 위해 `deleted_by_owner / deleted_by_partner` 플래그 처리
  - 채팅 메시지는 **기록 보존 정책상 물리 삭제하지 않음**
- ✅ 내가 등록한 방(rooms):
  - `status = CLOSED`
  - `deleted = 1` 처리

---

### 4. N:N 관계 처리 구조 개선
- `MemberRepository`에서 N:N 삽입 로직 제거
- 전용 리포지토리 분리
  - `MemberHobbyRepository`
  - `MemberPreferenceRepository`
  - `MemberPetRepository`
- bulk insert + delete 방식으로 일관된 갱신 패턴 적용

---

### 5. JWT 인증과 탈퇴 회원 차단 연동
- 로그인 시 탈퇴 회원 차단
- Refresh Token 재발급 시 탈퇴 회원 차단
- 탈퇴 시 Refresh Token DB 즉시 삭제

---

## 🧪 테스트 내용

다음 전체 플로우를 Postman으로 직접 검증 완료:

1. 회원가입 (취향/선호/펫 포함)
2. 로그인 → Access / Refresh Token 발급 확인
3. `/api/members/me` 조회
4. `/api/members/me` 프로필 수정
5. `/api/members/me` 회원 탈퇴
6. 탈퇴 후:
   - 동일 Access Token 접근 차단 확인
   - Refresh Token 재발급 차단 확인
   - DB 데이터 정합성 확인

✅ 모든 케이스 정상 동작 확인

---

## 📌 특이 사항
- 회원 삭제는 **물리 삭제가 아닌 soft delete 정책** 적용
- 채팅 메시지는 서비스 기록 보존 정책에 따라 유지
- 연관 데이터 정리 순서 트랜잭션으로 일괄 처리

---

## 🚀 관련 브랜치
- `feature/17-member-profile`
