### PR TITLE
feat: 회원가입 임시 프로필 이미지 업로드 및 마이페이지 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ node_modules/
 *.swo
 *.bak
 *.orig
+# 업로드 이미지 / 파일은 Git에 올리지 않는다
+/uploads/
+/upload/

--- a/src/main/java/com/roommate/common/config/WebMvcConfig.java
+++ b/src/main/java/com/roommate/common/config/WebMvcConfig.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.time.format.DateTimeFormatter;
@@ -64,5 +66,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Value("${file.upload.root-path}")
+    private String uploadRootPath;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/upload/**")
+                .addResourceLocations("file:" + uploadRootPath + "/");
     }
 }

--- a/src/main/java/com/roommate/common/exception/ErrorCode.java
+++ b/src/main/java/com/roommate/common/exception/ErrorCode.java
@@ -37,6 +37,20 @@ public enum ErrorCode {
     WORK_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "존재하지 않는 근무 유형입니다."),
     INVALID_WORK_TYPE(HttpStatus.BAD_REQUEST, "W002", "유효하지 않은 근무 유형 값입니다."),
 
+    // ===== FILE / 업로드 공통 =====
+    FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "F001", "업로드할 파일이 존재하지 않습니다."),
+    FILE_EMPTY(HttpStatus.BAD_REQUEST, "F002", "업로드 파일이 비어 있습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 업로드에 실패했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 삭제에 실패했습니다."),
+    FILE_PATH_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "F005", "파일 저장 경로가 올바르지 않습니다."),
+    FILE_ALREADY_USED(HttpStatus.CONFLICT, "F006", "이미 사용 중인 파일입니다."),
+
+    // ===== IMAGE / 이미지 업로드 =====
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMG001", "이미지 파일만 업로드할 수 있습니다."),
+    IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "IMG002", "이미지 파일 용량이 허용 범위를 초과했습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMG003", "이미지를 찾을 수 없습니다."),
+    IMAGE_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG004", "이미지 처리 중 오류가 발생했습니다."),
+
     // ===== ROOM / 방 관련 =====
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "R101", "존재하지 않는 방입니다."),
     ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "R102", "해당 방에 대한 권한이 없습니다."),
@@ -86,7 +100,6 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "R001", "잘못된 요청입니다."),
     MISSING_REQUIRED_VALUE(HttpStatus.BAD_REQUEST, "R002", "필수 입력값이 누락되었습니다."),
     INVALID_ENUM_VALUE(HttpStatus.BAD_REQUEST, "R003", "유효하지 않은 값입니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "R004", "파일 업로드에 실패했습니다."),
 
     // ===== BUSINESS / 리소스 관련 =====
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "요청한 리소스를 찾을 수 없습니다."),

--- a/src/main/java/com/roommate/common/security/SecurityConfig.java
+++ b/src/main/java/com/roommate/common/security/SecurityConfig.java
@@ -62,12 +62,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // ====== 뷰(페이지) 쪽: 모두 허용 ======
                 .antMatchers("/", "/index").permitAll()
                 .antMatchers("/rooms/**").permitAll()      // 상세 페이지 (뷰)
+                .antMatchers("/members/**").permitAll()      // 마이페이지 (뷰)
                 .antMatchers("/resources/**", "/favicon.ico").permitAll()
+                .antMatchers("/upload/**").permitAll()
+
                 // 2) 룸 조회용 API (지도/요약/상세 데이터) - 모두 허용
                 .antMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
 
                 // 3) 인증/회원가입/폼코드 등 공개 API
-                .antMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/refresh", "/api/members/form-codes").permitAll()
+                .antMatchers(
+                        "/api/auth/signup",
+                        "/api/auth/login",
+                        "/api/auth/refresh",
+                        "/api/members/form-codes",
+                        "/api/files/**").permitAll()
 
                 // 4) 테스트/로그인 관련 뷰 페이지 - 공개
                 .antMatchers("/auth/login-test", "/auth/me-test", "/auth/login").permitAll()
@@ -75,10 +83,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 // 5) 메인/지도/정적 리소스 - 공개
                 .antMatchers("/", "/room/map", "/index", "/resources/**").permitAll()
 
+                .antMatchers(HttpMethod.POST, "/api/members/**").authenticated()
+                .antMatchers(HttpMethod.PUT, "/api/members/**").authenticated()
+                .antMatchers(HttpMethod.DELETE, "/api/members/**").authenticated()
+
                 // 6) 방 작성/수정/삭제 API - 로그인 필요
                 .antMatchers(HttpMethod.POST, "/api/rooms/**").authenticated()
-                .antMatchers(HttpMethod.PUT,  "/api/rooms/**").authenticated()
-                .antMatchers(HttpMethod.DELETE,"/api/rooms/**").authenticated()
+                .antMatchers(HttpMethod.PUT, "/api/rooms/**").authenticated()
+                .antMatchers(HttpMethod.DELETE, "/api/rooms/**").authenticated()
 
                 // 7) 관리자 API
                 .antMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
@@ -40,4 +40,6 @@ public class SignUpRequest {
     private List<Long> hobbyIds;
     private List<Long> preferenceIds;
     private List<Long> petIds;
+
+    private Long profileTempFileId;
 }

--- a/src/main/java/com/roommate/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/roommate/domain/auth/dto/response/LoginResponse.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberRoleEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class LoginResponse {
     private Long memberId;
     private Long workTypeId;

--- a/src/main/java/com/roommate/domain/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/com/roommate/domain/auth/dto/response/SignUpResponse.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class SignUpResponse {
     private Long memberId;
     private Long workTypeId;

--- a/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.roommate.domain.auth.dto.response.LoginResponse;
 import com.roommate.domain.auth.dto.response.SignUpResponse;
 import com.roommate.domain.auth.entity.TokenRefreshEntity;
 import com.roommate.domain.auth.repository.TokenRefreshRepository;
+import com.roommate.domain.file.service.TempUploadFileService;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberEntity;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
@@ -30,6 +31,8 @@ import java.util.Date;
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
+
+    private final TempUploadFileService tempUploadFileService;
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -85,46 +88,52 @@ public class AuthServiceImpl implements AuthService {
      * MemberEntity → SignUpResponse 변환
      */
     private SignUpResponse toSignUpResponse(MemberEntity memberEntity) {
-        SignUpResponse signUpResponse = new SignUpResponse();
-        signUpResponse.setMemberId(memberEntity.getMemberId());
-        signUpResponse.setWorkTypeId(memberEntity.getWorkTypeId());
-        signUpResponse.setEmail(memberEntity.getEmail());
-        signUpResponse.setName(memberEntity.getName());
-        signUpResponse.setPhone(memberEntity.getPhone());
-        signUpResponse.setPhotoUrl(memberEntity.getPhotoUrl());
-        signUpResponse.setSleepTime(memberEntity.getSleepTime());
-        signUpResponse.setSmoking(memberEntity.getSmoking());
-        signUpResponse.setDrinking(memberEntity.getDrinking());
-        signUpResponse.setMbti(memberEntity.getMbti());
-        return signUpResponse;
+        return new SignUpResponse(
+                memberEntity.getMemberId(),
+                memberEntity.getWorkTypeId(),
+                memberEntity.getEmail(),
+                memberEntity.getName(),
+                memberEntity.getPhone(),
+                memberEntity.getPhotoUrl(),
+                memberEntity.getSleepTime(),
+                memberEntity.getSmoking(),
+                memberEntity.getDrinking(),
+                memberEntity.getMbti());
     }
 
     /**
      * MemberEntity,jwt → toLoginUpResponse 변환
      */
     private LoginResponse toLoginResponse(MemberEntity memberEntity, String accessToken, String refreshToken) {
-        LoginResponse loginResponse = new LoginResponse();
-        loginResponse.setMemberId(memberEntity.getMemberId());
-        loginResponse.setWorkTypeId(memberEntity.getWorkTypeId());
-        loginResponse.setEmail(memberEntity.getEmail());
-        loginResponse.setName(memberEntity.getName());
-        loginResponse.setPhone(memberEntity.getPhone());
-        loginResponse.setPhotoUrl(memberEntity.getPhotoUrl());
-        loginResponse.setSleepTime(memberEntity.getSleepTime());
-        loginResponse.setSmoking(memberEntity.getSmoking() != null ? memberEntity.getSmoking() : MemberSmokingEnum.NON_SMOKER);
-        loginResponse.setDrinking(memberEntity.getDrinking() != null ? memberEntity.getDrinking() : MemberDrinkingEnum.NONE);
-        loginResponse.setMbti(memberEntity.getMbti());
-        loginResponse.setMemberRoleEnum(memberEntity.getRole());
-        loginResponse.setAccessToken(accessToken);
-        loginResponse.setRefreshToken(refreshToken);
-        loginResponse.setTokenType("Bearer");
-        return loginResponse;
+        return new LoginResponse(
+                memberEntity.getMemberId(),
+                memberEntity.getWorkTypeId(),
+                memberEntity.getEmail(),
+                memberEntity.getName(),
+                memberEntity.getPhone(),
+                memberEntity.getPhotoUrl(),
+                memberEntity.getSleepTime(),
+                memberEntity.getSmoking() != null ? memberEntity.getSmoking() : MemberSmokingEnum.NON_SMOKER,
+                memberEntity.getDrinking() != null ? memberEntity.getDrinking() : MemberDrinkingEnum.NONE,
+                memberEntity.getMbti(),
+                memberEntity.getRole(),
+                accessToken,
+                refreshToken,
+                "Bearer"
+        );
     }
 
     @Override
     @Transactional
     public SignUpResponse signUp(SignUpRequest signUpRequest) {
+
         validateEmailDuplication(signUpRequest.getEmail());
+
+        if (signUpRequest.getProfileTempFileId() != null) {
+            String photoUrl = tempUploadFileService.useTempFile(signUpRequest.getProfileTempFileId());
+            signUpRequest.setPhotoUrl(photoUrl);
+        }
+
         MemberEntity memberEntity = createMemberFromSignUpRequest(signUpRequest);
         memberRepository.save(memberEntity);
         Long memberId = memberEntity.getMemberId();

--- a/src/main/java/com/roommate/domain/file/controller/FileUploadRestController.java
+++ b/src/main/java/com/roommate/domain/file/controller/FileUploadRestController.java
@@ -1,0 +1,25 @@
+package com.roommate.domain.file.controller;
+
+import com.roommate.domain.file.dto.response.TempUploadFileResponse;
+import com.roommate.domain.file.entity.TempUploadFileEntity;
+import com.roommate.domain.file.service.TempUploadFileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileUploadRestController {
+
+    private final TempUploadFileService tempUploadFileService;
+
+    @PutMapping("/temp/profile")
+    public TempUploadFileResponse uploadTempProfileImage(@RequestParam("file") MultipartFile file) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileService.uploadTempProfileImage(file);
+        return new TempUploadFileResponse(tempUploadFileEntity.getTempFileId(), tempUploadFileEntity.getTempPath());
+    }
+}

--- a/src/main/java/com/roommate/domain/file/dto/request/TempUploadFileUseRequest.java
+++ b/src/main/java/com/roommate/domain/file/dto/request/TempUploadFileUseRequest.java
@@ -1,0 +1,11 @@
+package com.roommate.domain.file.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TempUploadFileUseRequest {
+}

--- a/src/main/java/com/roommate/domain/file/dto/response/TempUploadFileResponse.java
+++ b/src/main/java/com/roommate/domain/file/dto/response/TempUploadFileResponse.java
@@ -1,4 +1,4 @@
-package com.roommate.domain.member.dto.response;
+package com.roommate.domain.file.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -8,7 +8,7 @@ import lombok.Getter;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @AllArgsConstructor
-public class PetResponse {
-    private Long PetId;
-    private String PetName;
+public class TempUploadFileResponse {
+    Long tempFileId;
+    String tempUrl;
 }

--- a/src/main/java/com/roommate/domain/file/entity/TempUploadFileEntity.java
+++ b/src/main/java/com/roommate/domain/file/entity/TempUploadFileEntity.java
@@ -1,0 +1,18 @@
+package com.roommate.domain.file.entity;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class TempUploadFileEntity {
+    private Long tempFileId;
+    private String originalName;
+    private String tempPath;
+    private Integer used;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/roommate/domain/file/repository/TempUploadFileRepository.java
+++ b/src/main/java/com/roommate/domain/file/repository/TempUploadFileRepository.java
@@ -1,0 +1,23 @@
+package com.roommate.domain.file.repository;
+
+import com.roommate.domain.file.entity.TempUploadFileEntity;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Mapper
+public interface TempUploadFileRepository {
+
+    TempUploadFileEntity findById(@Param("tempFileId") Long tempFileId);
+
+    List<TempUploadFileEntity> findExpired(@Param("threshold") LocalDateTime threshold);
+
+    void save(TempUploadFileEntity entity);
+
+    void updateUsed(TempUploadFileEntity entity);
+
+    void deleteById(@Param("tempFileId") Long tempFileId);
+
+}

--- a/src/main/java/com/roommate/domain/file/scheduler/TempUploadCleanupScheduler.java
+++ b/src/main/java/com/roommate/domain/file/scheduler/TempUploadCleanupScheduler.java
@@ -1,0 +1,21 @@
+package com.roommate.domain.file.scheduler;
+
+import com.roommate.domain.file.service.TempUploadFileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TempUploadCleanupScheduler {
+
+    private final TempUploadFileService tempUploadFileService;
+
+    /**
+     * 매 시간마다 6시간 이상 지난 미사용 temp 파일 정리
+     */
+    @Scheduled(cron = "0 0 * * * *") // 매 정시
+    public void cleanup() {
+        tempUploadFileService.cleanupExpiredTempFiles(6);
+    }
+}

--- a/src/main/java/com/roommate/domain/file/service/FileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/FileStorageService.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+
+    String storeProfileImg(Long memberId, MultipartFile multipartFile);
+
+    String storeRoomImage(Long roomId, MultipartFile multipartFile);
+
+    String storeTempImage(String category, MultipartFile multipartFile);
+
+    void deleteByUrl(String url);
+}

--- a/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
@@ -1,0 +1,98 @@
+package com.roommate.domain.file.service;
+
+import com.roommate.common.exception.ApiException;
+import com.roommate.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class LocalFileStorageService implements FileStorageService {
+
+    @Value("${file.upload.root-path}")
+    private String uploadRootPath;
+
+    @Override
+    public String storeProfileImg(Long memberId, MultipartFile multipartFile) {
+        return storeImage("profile", "member-" + memberId, multipartFile);
+    }
+
+    @Override
+    public String storeRoomImage(Long roomId, MultipartFile multipartFile) {
+        return storeImage("room", "room-" + roomId, multipartFile);
+    }
+
+    private String storeImage(String subDir, String prefix, MultipartFile file) {
+
+        // ✅ 1. 파일 존재 여부
+        if (file == null) {
+            throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        // ✅ 2. 파일 비어있는지
+        if (file.isEmpty()) {
+            throw new ApiException(ErrorCode.FILE_EMPTY);
+        }
+
+        // ✅ 3. 이미지 타입 검증
+        if (file.getContentType() == null || !file.getContentType().startsWith("image/")) {
+            throw new ApiException(ErrorCode.INVALID_IMAGE_TYPE);
+        }
+
+        // ✅ 4. 저장 디렉토리 준비
+        File dir = new File(uploadRootPath, subDir);  // ./uploads/profile or ./uploads/room
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new ApiException(ErrorCode.FILE_PATH_INVALID);
+        }
+
+        // ✅ 5. 확장자 추출
+        String originalName = file.getOriginalFilename();
+        String ext = "";
+
+        if (originalName != null && originalName.contains(".")) {
+            ext = originalName.substring(originalName.lastIndexOf("."));
+        }
+
+        // ✅ 6. 최종 파일명 생성
+        String filename = prefix + "-" + System.currentTimeMillis() + ext;
+        File dest = new File(dir, filename);
+
+        // ✅ 7. 파일 저장
+        try {
+            file.transferTo(dest);
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        // ✅ 8. 클라이언트 접근 URL 반환
+        return "/upload/" + subDir + "/" + filename;
+    }
+
+    @Override
+    public String storeTempImage(String category, MultipartFile multipartFile) {
+        String subDir = "temp/" + category;
+        String prefix = "tmp-" + category;
+        return storeImage(subDir,prefix,multipartFile);
+    }
+
+    @Override
+    public void deleteByUrl(String url) {
+        if (url == null || !url.startsWith("/upload/")) {
+            return;
+        }
+        String relativePath = url.substring("/upload/".length());
+        File file = new File(uploadRootPath, relativePath);
+
+        if (file.exists() && file.isFile()) {
+            boolean deleted = file.delete();
+            if(!deleted){
+                System.out.println("프로필 이미지 삭제 실패: " + file.getAbsolutePath());
+            }
+        }
+    }
+}

--- a/src/main/java/com/roommate/domain/file/service/TempUploadFileService.java
+++ b/src/main/java/com/roommate/domain/file/service/TempUploadFileService.java
@@ -1,0 +1,13 @@
+package com.roommate.domain.file.service;
+
+import com.roommate.domain.file.entity.TempUploadFileEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface TempUploadFileService {
+
+    public TempUploadFileEntity uploadTempProfileImage(MultipartFile file);
+
+    public String useTempFile(Long tempFileId);
+
+    public void cleanupExpiredTempFiles(int hours);
+}

--- a/src/main/java/com/roommate/domain/file/service/TempUploadFileServiceImpl.java
+++ b/src/main/java/com/roommate/domain/file/service/TempUploadFileServiceImpl.java
@@ -1,0 +1,63 @@
+package com.roommate.domain.file.service;
+
+import com.roommate.common.exception.ApiException;
+import com.roommate.common.exception.ErrorCode;
+import com.roommate.domain.file.entity.TempUploadFileEntity;
+import com.roommate.domain.file.repository.TempUploadFileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TempUploadFileServiceImpl implements TempUploadFileService {
+
+    private final FileStorageService fileStorageService;
+    private final TempUploadFileRepository tempUploadFileRepository;
+
+
+    @Override
+    @Transactional
+    public TempUploadFileEntity uploadTempProfileImage(MultipartFile file) {
+        String url = fileStorageService.storeTempImage("profile", file);
+
+        TempUploadFileEntity tempUploadFileEntity = new TempUploadFileEntity();
+        tempUploadFileEntity.setOriginalName(file.getOriginalFilename());
+        tempUploadFileEntity.setTempPath(url);
+        tempUploadFileEntity.setUsed(0);
+        tempUploadFileRepository.save(tempUploadFileEntity);
+        return tempUploadFileEntity;
+    }
+
+    @Override
+    @Transactional
+    public String useTempFile(Long tempFileId) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileRepository.findById(tempFileId);
+        if (tempUploadFileEntity == null) {
+            throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+        if (tempUploadFileEntity.getUsed() != null && tempUploadFileEntity.getUsed() == 1) {
+            throw new ApiException(ErrorCode.FILE_ALREADY_USED);
+        }
+
+        tempUploadFileEntity.setUsed(1);
+        tempUploadFileRepository.updateUsed(tempUploadFileEntity);
+        return tempUploadFileEntity.getTempPath();
+    }
+
+    @Override
+    @Transactional
+    public void cleanupExpiredTempFiles(int hours) {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(hours);
+        List<TempUploadFileEntity> expiredList = tempUploadFileRepository.findExpired(threshold);
+
+        for (TempUploadFileEntity e : expiredList) {
+            fileStorageService.deleteByUrl(e.getTempPath());
+            tempUploadFileRepository.deleteById(e.getTempFileId());
+        }
+    }
+}

--- a/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -51,6 +52,12 @@ public class MemberRestController {
     public ResponseEntity<MemberResponse> updateMemberProfile(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody MemberProfileUpdateRequest MemberProfileUpdateRequest) {
         MemberResponse updated = memberService.updateMemberProfile(userDetails.getMemberId(), MemberProfileUpdateRequest);
         // 200 OK 로 반환해도 되지만, Location을 주고 싶으면 created 형태도 가능.
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping("/me/photo")
+    public ResponseEntity<MemberResponse> updateProfilePhoto(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam("file") MultipartFile multipartFile) {
+        MemberResponse updated = memberService.updateMemberProfilePhoto(userDetails.getMemberId(), multipartFile);
         return ResponseEntity.ok(updated);
     }
 

--- a/src/main/java/com/roommate/domain/member/controller/MemberViewController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberViewController.java
@@ -1,7 +1,18 @@
 package com.roommate.domain.member.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
+@RequestMapping("members")
+@RequiredArgsConstructor
 public class MemberViewController {
+
+    @GetMapping("/mypage")
+    public String mypage() {
+        // /WEB-INF/views/members/mypage.jsp 를 의미
+        return "members/mypage";
+    }
 }

--- a/src/main/java/com/roommate/domain/member/dto/response/FormCodesResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/FormCodesResponse.java
@@ -2,12 +2,14 @@ package com.roommate.domain.member.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class FormCodesResponse {
     private List<WorkTypeResponse> workTypes;
     private List<HobbyResponse> hobbies;

--- a/src/main/java/com/roommate/domain/member/dto/response/HobbyResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/HobbyResponse.java
@@ -2,10 +2,12 @@ package com.roommate.domain.member.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class HobbyResponse {
     private Long HobbyId;
     private String HobbyName;

--- a/src/main/java/com/roommate/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/MemberResponse.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberRoleEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import java.util.List;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class MemberResponse {
     private Long memberId;
     private Long workTypeId;

--- a/src/main/java/com/roommate/domain/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/PreferenceResponse.java
@@ -2,10 +2,13 @@ package com.roommate.domain.member.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class PreferenceResponse {
     private Long PreferenceId;
     private String PreferenceName;

--- a/src/main/java/com/roommate/domain/member/dto/response/WorkTypeResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/WorkTypeResponse.java
@@ -2,12 +2,12 @@ package com.roommate.domain.member.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.Data;
-
-import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@Data
+@Getter
+@AllArgsConstructor
 public class WorkTypeResponse {
     private Long workTypeId;
     private String workTypeName;

--- a/src/main/java/com/roommate/domain/member/service/MemberService.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberService.java
@@ -6,12 +6,10 @@ import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
-	/**
-	 * 회원조회
-	 */
 	public MemberResponse memberInfo(Long memberId);
 
 	public MemberResponse updateMemberProfile(Long memberId, MemberProfileUpdateRequest request);
@@ -19,4 +17,6 @@ public interface MemberService {
 	void deleteMember(Long memberId);
 
 	public FormCodesResponse getFormCodes();
+
+	public MemberResponse updateMemberProfilePhoto(Long memberId, MultipartFile multipartFile);
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
@@ -3,9 +3,9 @@ package com.roommate.domain.member.service;
 import com.roommate.common.exception.ApiException;
 import com.roommate.common.exception.ErrorCode;
 import com.roommate.domain.auth.repository.TokenRefreshRepository;
-import com.roommate.domain.chat.repository.ChatMessageRepository;
 import com.roommate.domain.chat.repository.ChatRoomRepository;
 import com.roommate.domain.favorite.repository.FavoriteRepository;
+import com.roommate.domain.file.service.FileStorageService;
 import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.*;
 import com.roommate.domain.member.entity.*;
@@ -16,12 +16,15 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
+
+    private final FileStorageService fileStorageService;
 
     private final MemberRepository memberRepository;
     private final WorkTypeRepository workTypeRepository;
@@ -40,63 +43,60 @@ public class MemberServiceImpl implements MemberService {
     private final TokenRefreshRepository tokenRefreshRepository;
 
     private WorkTypeResponse toWorkTypeResponse(WorkTypeEntity workTypeEntity) {
-        WorkTypeResponse workTypeResponse = new WorkTypeResponse();
-        workTypeResponse.setWorkTypeId(workTypeEntity.getWorkTypeId());
-        workTypeResponse.setWorkTypeName(workTypeEntity.getWorkTypeName());
-        return workTypeResponse;
+        return new WorkTypeResponse(workTypeEntity.getWorkTypeId(), workTypeEntity.getWorkTypeName());
     }
 
     private HobbyResponse toHobbyResponse(HobbyEntity hobbyEntity) {
-        HobbyResponse hobbyResponse = new HobbyResponse();
-        hobbyResponse.setHobbyId(hobbyEntity.getHobbyId());
-        hobbyResponse.setHobbyName(hobbyEntity.getHobbyName());
-        return hobbyResponse;
+        return new HobbyResponse(hobbyEntity.getHobbyId(), hobbyEntity.getHobbyName());
     }
 
     private PreferenceResponse toPreferenceResponse(PreferenceEntity preferenceEntity) {
-        PreferenceResponse preferenceResponse = new PreferenceResponse();
-        preferenceResponse.setPreferenceId(preferenceEntity.getPreferenceId());
-        preferenceResponse.setPreferenceName(preferenceEntity.getPreferenceName());
-        return preferenceResponse;
+        return new PreferenceResponse(preferenceEntity.getPreferenceId(), preferenceEntity.getPreferenceName());
     }
 
     private PetResponse toPetResponse(PetEntity petEntity) {
-        PetResponse petResponse = new PetResponse();
-        petResponse.setPetId(petEntity.getPetId());
-        petResponse.setPetName(petEntity.getPetName());
-        return petResponse;
+        return new PetResponse(petEntity.getPetId(), petEntity.getPetName());
     }
 
     private MemberResponse toMemberResponse(MemberEntity memberEntity, WorkTypeEntity workTypeEntity, List<HobbyEntity> hobbyEntities, List<PreferenceEntity> preferenceEntities, List<PetEntity> petEntities) {
-        MemberResponse memberResponse = new MemberResponse();
-        memberResponse.setMemberId(memberEntity.getMemberId());
-        memberResponse.setEmail(memberEntity.getEmail());
-        memberResponse.setName(memberEntity.getName());
-        memberResponse.setPhone(memberEntity.getPhone());
-        memberResponse.setPhotoUrl(memberEntity.getPhotoUrl());
-        if (workTypeEntity != null) {
-            memberResponse.setWorkTypeId(workTypeEntity.getWorkTypeId());
-            memberResponse.setWorkTypeName(workTypeEntity.getWorkTypeName());
+
+        if (workTypeEntity.getWorkTypeId() != null && workTypeEntity == null) {
+            throw new ApiException(ErrorCode.WORK_TYPE_NOT_FOUND);
         }
-        memberResponse.setSleepTime(memberEntity.getSleepTime());
-        memberResponse.setSmoking(memberEntity.getSmoking() != null ? memberEntity.getSmoking() : MemberSmokingEnum.NON_SMOKER);
-        memberResponse.setDrinking(memberEntity.getDrinking() != null ? memberEntity.getDrinking() : MemberDrinkingEnum.NONE);
-        memberResponse.setMbti(memberEntity.getMbti());
-        memberResponse.setMemberRoleEnum(memberEntity.getRole());
-        memberResponse.setHobbies(hobbyEntities.stream().map(this::toHobbyResponse).toList());
-        memberResponse.setPreferences(preferenceEntities.stream().map(this::toPreferenceResponse).toList());
-        memberResponse.setPets(petEntities.stream().map(this::toPetResponse).toList());
-        return memberResponse;
+
+        Long workTypeId = null;
+        String workTypeName = null;
+
+        if (workTypeEntity != null) {
+            workTypeId = workTypeEntity.getWorkTypeId();
+            workTypeName = workTypeEntity.getWorkTypeName();
+        }
+
+        return new MemberResponse(
+                memberEntity.getMemberId(),
+                workTypeId,
+                workTypeName,
+                memberEntity.getEmail(),
+                memberEntity.getName(),
+                memberEntity.getPhone(),
+                memberEntity.getPhotoUrl(),
+                memberEntity.getSleepTime(),
+                memberEntity.getSmoking() != null ? memberEntity.getSmoking() : MemberSmokingEnum.NON_SMOKER,
+                memberEntity.getDrinking() != null ? memberEntity.getDrinking() : MemberDrinkingEnum.NONE,
+                memberEntity.getMbti(),
+                memberEntity.getRole(),
+                hobbyEntities.stream().map(this::toHobbyResponse).toList(),
+                preferenceEntities.stream().map(this::toPreferenceResponse).toList(),
+                petEntities.stream().map(this::toPetResponse).toList());
     }
 
     @Override
     public FormCodesResponse getFormCodes() {
-        FormCodesResponse formCodesResponse = new FormCodesResponse();
-        formCodesResponse.setWorkTypes(workTypeRepository.findAll().stream().map(this::toWorkTypeResponse).toList());
-        formCodesResponse.setHobbies(hobbyRepository.findAll().stream().map(this::toHobbyResponse).toList());
-        formCodesResponse.setPreferences(preferenceRepository.findAll().stream().map(this::toPreferenceResponse).toList());
-        formCodesResponse.setPets(petRepository.findAll().stream().map(this::toPetResponse).toList());
-        return formCodesResponse;
+        List<WorkTypeResponse> workTypes = workTypeRepository.findAll().stream().map(this::toWorkTypeResponse).toList();
+        List<HobbyResponse> hobbies = hobbyRepository.findAll().stream().map(this::toHobbyResponse).toList();
+        List<PreferenceResponse> preferences = preferenceRepository.findAll().stream().map(this::toPreferenceResponse).toList();
+        List<PetResponse> pets = petRepository.findAll().stream().map(this::toPetResponse).toList();
+        return new FormCodesResponse(workTypes, hobbies, preferences, pets);
     }
 
     @Override
@@ -199,12 +199,12 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원 탈퇴 처리
-     *
+     * <p>
      * 왜 이렇게 썼는지:
      * - 실제 members row를 삭제하지 않고 deleted 플래그로 관리(soft delete)해서
-     *   FK 제약, 채팅/방 이력, 통계 데이터를 보존하기 위함.
+     * FK 제약, 채팅/방 이력, 통계 데이터를 보존하기 위함.
      * - 연관 테이블은 도메인 정책에 맞게 정리하고,
-     *   채팅 메시지는 남기되 채팅방은 "탈퇴한 회원 기준으로만" 나가기 처리한다.
+     * 채팅 메시지는 남기되 채팅방은 "탈퇴한 회원 기준으로만" 나가기 처리한다.
      */
     @Override
     @Transactional
@@ -247,5 +247,37 @@ public class MemberServiceImpl implements MemberService {
 
         // 6) 최종적으로 members.deleted = 1 로 soft delete
         memberRepository.softDeleteMember(memberId);
+    }
+
+    @Override
+    @Transactional
+    public MemberResponse updateMemberProfilePhoto(Long memberId, MultipartFile multipartFile) {
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (memberEntity.getDeleted() == 1) {
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
+
+        String oldPhotoUrl = memberEntity.getPhotoUrl();
+
+        String newPhotoUrl = fileStorageService.storeProfileImg(memberId, multipartFile);
+
+        memberEntity.setPhotoUrl(newPhotoUrl);
+        memberRepository.updateMember(memberEntity);
+
+        fileStorageService.deleteByUrl(oldPhotoUrl);
+
+        WorkTypeEntity workTypeEntity = null;
+        if (memberEntity.getWorkTypeId() != null) {
+            workTypeEntity = workTypeRepository.findById(memberEntity.getWorkTypeId())
+                    .orElse(null);
+        }
+
+        List<HobbyEntity> hobbyEntities = hobbyRepository.findByMemberId(memberId);
+        List<PreferenceEntity> preferenceEntities = preferenceRepository.findByMemberId(memberId);
+        List<PetEntity> petEntities = petRepository.findByMemberId(memberId);
+
+        return toMemberResponse(memberEntity, workTypeEntity, hobbyEntities, preferenceEntities, petEntities);
     }
 }

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -23,3 +23,6 @@ kakao.map.api.key=REST_API_키
 kakao.js.key=JavaScript_키
 kakao.local.base-url=https://dapi.kakao.com
 kakao.ka.origin=roommate-service
+
+#사진 업로드
+file.upload.root-path=

--- a/src/main/resources/mapper/file/TempUploadFile.xml
+++ b/src/main/resources/mapper/file/TempUploadFile.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.file.repository.TempUploadFileRepository">
+    <resultMap id="fileMap" type="com.roommate.domain.file.entity.TempUploadFileEntity">
+        <id property="tempFileId" column="temp_file_id"/>
+        <result property="originalName" column="original_name"/>
+        <result property="tempPath" column="temp_path"/>
+        <result property="used" column="used"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <select id="findById" resultMap="fileMap">
+        SELECT *
+        FROM temp_upload_files
+        WHERE temp_file_id = #{tempFileId}
+    </select>
+
+    <select id="findExpired" resultMap="fileMap">
+        SELECT *
+        FROM temp_upload_files
+        WHERE used = 0 AND created_at <![CDATA[ < ]]> #{threshold}
+    </select>
+
+    <insert id="save" useGeneratedKeys="true" keyProperty="tempFileId"
+            parameterType="com.roommate.domain.file.entity.TempUploadFileEntity">
+        INSERT INTO temp_upload_files ( original_name , temp_path , used )
+        VALUES ( #{originalName} , #{tempPath} , #{used} )
+    </insert>
+
+    <update id="updateUsed" parameterType="com.roommate.domain.file.entity.TempUploadFileEntity">
+        UPDATE temp_upload_files
+        <set>
+            used = #{used},
+        </set>
+        WHERE
+        temp_file_id = #{tempFileId}
+    </update>
+
+    <delete id="deleteById">
+        DELETE
+        FROM temp_upload_files
+        WHERE temp_file_id = #{tempFileId}
+    </delete>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -65,13 +65,11 @@
 	
 	    <!-- ✅ 정적 리소스 허용(css나 js를 선언했을경우 이걸 안하면 디스패처에서 가로채서 인식을 못함)) -->
     <mvc:resources mapping="/resources/**" location="/resources/"></mvc:resources>
-    
+	<!--  업로드 파일 정적 리소스 매핑 추가 -->
+	<mvc:resources mapping="/upload/**" location="file:${file.upload.root-path}/" />
 	<!-- 사진 10메가로 올리기 위해서 -->
 	<bean id="multipartResolver"
 		class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
-		<property name="maxUploadSize">
-			<value>10485760</value>
-		</property>
 	</bean>
 	
 </beans>

--- a/src/main/webapp/WEB-INF/views/auth/login.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/login.jsp
@@ -28,6 +28,16 @@
     <!-- 회원가입 탭 -->
     <div id="registerTab" class="auth-tab-content hidden">
       <form id="registerForm">
+
+        <div class="register-profile-photo-wrapper">
+          <img id="regProfilePhoto" src="" alt="프로필 사진" class="register-profile-photo">
+          <input type="file" id="regPhotoFileInput" accept="image/*" style="display: none;"/>
+          <input type="hidden" id="regProfileTempFileId" />
+          <button type="button" id="btnRegPhotoUpload" class="btn-regPhoto-upload">
+            사진 추가
+          </button>
+        </div>
+
         <!-- 1. 기본 정보: 이름 -->
         <div class="form-row">
           <div class="form-group">
@@ -103,22 +113,24 @@
         <div class="form-group">
           <label for="regMbti">MBTI</label>
           <select id="regMbti">
-            <option value="">선택 안 함</option>
-            <option value="INTJ">INTJ</option><option value="INTP">INTP</option>
-            <option value="INFJ">INFJ</option><option value="INFP">INFP</option>
-            <option value="ISTJ">ISTJ</option><option value="ISTP">ISTP</option>
-            <option value="ISFJ">ISFJ</option><option value="ISFP">ISFP</option>
-            <option value="ENTJ">ENTJ</option><option value="ENTP">ENTP</option>
-            <option value="ENFJ">ENFJ</option><option value="ENFP">ENFP</option>
-            <option value="ESTJ">ESTJ</option><option value="ESTP">ESTP</option>
-            <option value="ESFJ">ESFJ</option><option value="ESFP">ESFP</option>
+              <option value="">선택 안함</option>
+              <option value="INTJ">INTJ</option>
+              <option value="INTP">INTP</option>
+              <option value="INFJ">INFJ</option>
+              <option value="INFP">INFP</option>
+              <option value="ISTJ">ISTJ</option>
+              <option value="ISTP">ISTP</option>
+              <option value="ISFJ">ISFJ</option>
+              <option value="ISFP">ISFP</option>
+              <option value="ENTJ">ENTJ</option>
+              <option value="ENTP">ENTP</option>
+              <option value="ENFJ">ENFJ</option>
+              <option value="ENFP">ENFP</option>
+              <option value="ESTJ">ESTJ</option>
+              <option value="ESTP">ESTP</option>
+              <option value="ESFJ">ESFJ</option>
+              <option value="ESFP">ESFP</option>
           </select>
-        </div>
-
-        <!-- 10. 프로필 사진 URL -->
-        <div class="form-group">
-          <label for="regPhoto">프로필 사진 URL (선택)</label>
-          <input type="text" id="regPhoto" placeholder="https://example.com/photo.jpg">
         </div>
 
         <!-- 11. 취미 다중 선택 -->

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -1,12 +1,53 @@
-<%@ page contentType="text/html;charset=UTF-8" %>
-<div class="header">
-  <div class="logo">Roommate</div>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
 
+<link rel="stylesheet"
+      href="${pageContext.request.contextPath}/resources/css/common/header.css" />
+
+<div class="header">
+  <!-- 왼쪽: 로고 + GNB -->
+  <div class="header-left">
+    <a href="${pageContext.request.contextPath}/" class="logo">룸메이트</a>
+
+    <ul class="gnb">
+      <li><a href="${pageContext.request.contextPath}/">홈</a></li>
+      <li><a href="${pageContext.request.contextPath}/rooms/map">지도 검색</a></li>
+      <li><a href="${pageContext.request.contextPath}/rooms">룸메이트 찾기</a></li>
+      <li><a href="${pageContext.request.contextPath}/community">커뮤니티</a></li>
+      <li><a href="${pageContext.request.contextPath}/notices">공지사항</a></li>
+    </ul>
+  </div>
+
+  <!-- 오른쪽: 검색 / 알림 / 로그인/프로필 -->
   <div class="header-right">
-    <button id="btnOpenLogin" type="button">로그인</button>
-    <button id="btnOpenRegister" type="button">회원가입</button>
-    <button id="btnLogout" type="button">로그아웃</button>
+    <!-- 검색 아이콘 -->
+    <button type="button" class="header-icon-btn" id="btnHeaderSearch">
+      🔍
+    </button>
+
+    <!-- 알림 아이콘 + 뱃지 (나중에 알림 API 붙이면 숫자 갱신) -->
+    <button type="button" class="header-icon-btn" id="btnHeaderNotification">
+      🔔
+      <span class="badge" id="notificationCount" style="display:none;">0</span>
+    </button>
+
+    <!-- 로그인/회원가입 버튼: 비로그인일 때만 노출 -->
+    <div id="headerAuthButtons">
+      <button id="btnOpenLogin" type="button" class="header-text-btn">로그인</button>
+      <button id="btnOpenRegister" type="button" class="header-text-btn">회원가입</button>
+    </div>
+
+    <!-- 프로필 + 로그아웃: 로그인일 때만 노출 -->
+    <div id="headerProfileArea" class="header-profile" style="display:none;">
+      <span class="icon-user">👤</span>
+      <a href="${pageContext.request.contextPath}/members/mypage"
+         class="header-username"
+         id="headerUsername">user</a>
+      <button id="btnLogout" type="button" class="header-text-btn">로그아웃</button>
+    </div>
   </div>
 </div>
 
+<script type="module" src="${pageContext.request.contextPath}/resources/js/common/header.js"></script>
+
+<!-- 로그인/회원가입 모달 (login.jsp가 모달 전용이라면 그대로 include) -->
 <jsp:include page="/WEB-INF/views/auth/login.jsp"/>

--- a/src/main/webapp/WEB-INF/views/members/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypage.jsp
@@ -1,0 +1,158 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+  <title>마이페이지 - Roommate</title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/member/mypage.css">
+</head>
+<body>
+
+<jsp:include page="/WEB-INF/views/common/header.jsp" />
+
+<div class="mypage-container">
+  <!-- 왼쪽: 프로필 카드 -->
+  <section class="mypage-left">
+    <div class="profile-card">
+      <div class="profile-photo-wrapper">
+        <img id="profilePhoto" src="" alt="프로필 사진" class="profile-photo">
+        <input type="file" id="photoFileInput" accept="image/*" style="display: none;"/>
+        <button type="button" class="btn-photo-upload" onclick="document.getElementById('photoFileInput').click();">
+        사진 변경
+        </button>
+      </div>
+      <div class="profile-main-info">
+        <h2 id="profileName">이름</h2>
+        <p id="profileEmail" class="profile-email">email@example.com</p>
+        <p id="profilePhone" class="profile-phone">010-0000-0000</p>
+      </div>
+
+      <div class="profile-tags">
+        <span class="tag" id="profileWorkType">직업/라이프스타일</span>
+        <span class="tag" id="profileMbti">MBTI</span>
+        <span class="tag" id="profileSmoking">흡연</span>
+        <span class="tag" id="profileDrinking">음주</span>
+        <span class="tag" id="profileSleepTime">수면 시간</span>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>취미</h3>
+        <div id="profileHobbies" class="chip-list"></div>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>생활 선호</h3>
+        <div id="profilePreferences" class="chip-list"></div>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>반려동물</h3>
+        <div id="profilePets" class="chip-list"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 오른쪽: 내 정보 수정 폼 -->
+  <section class="mypage-right">
+    <h2>내 프로필 수정</h2>
+
+    <form id="mypageForm">
+      <div class="form-row">
+        <label for="mpName">이름</label>
+        <input type="text" id="mpName" maxlength="50">
+      </div>
+
+      <div class="form-row">
+        <label for="mpPhone">전화번호</label>
+        <input type="text" id="mpPhone" placeholder="010-1234-5678">
+      </div>
+
+      <div class="form-row">
+        <label for="mpWorkType">직업/라이프스타일</label>
+        <select id="mpWorkType">
+          <option value="">선택해주세요</option>
+          <!-- /api/members/form-codes로 채움 -->
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpSleepTime">취침 시간</label>
+        <select id="mpSleepTime">
+          <option value="">선택 안 함</option>
+          <option value="EARLY">일찍 잠 (22시 이전)</option>
+          <option value="NORMAL">보통 (22~24시)</option>
+          <option value="LATE">늦게 잠 (자정 이후)</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpSmoking">흡연 여부</label>
+        <select id="mpSmoking">
+          <option value="NON_SMOKER">비흡연</option>
+          <option value="SMOKER">흡연</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpDrinking">음주 빈도</label>
+        <select id="mpDrinking">
+          <option value="NONE">안 마심</option>
+          <option value="SOCIAL">가끔</option>
+          <option value="OFTEN">자주</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpMbti">MBTI</label>
+        <select id="mpMbti">
+            <option value="">선택 안함</option>
+            <option value="INTJ">INTJ</option>
+            <option value="INTP">INTP</option>
+            <option value="INFJ">INFJ</option>
+            <option value="INFP">INFP</option>
+            <option value="ISTJ">ISTJ</option>
+            <option value="ISTP">ISTP</option>
+            <option value="ISFJ">ISFJ</option>
+            <option value="ISFP">ISFP</option>
+            <option value="ENTJ">ENTJ</option>
+            <option value="ENTP">ENTP</option>
+            <option value="ENFJ">ENFJ</option>
+            <option value="ENFP">ENFP</option>
+            <option value="ESTJ">ESTJ</option>
+            <option value="ESTP">ESTP</option>
+            <option value="ESFJ">ESFJ</option>
+            <option value="ESFP">ESFP</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label>취미</label>
+        <div id="mpHobbyCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-row">
+        <label>생활 선호</label>
+        <div id="mpPreferenceCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-row">
+        <label>반려동물</label>
+        <div id="mpPetCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <span id="mypageError" class="form-error"></span>
+        <button type="submit" class="btn-primary">저장하기</button>
+      </div>
+    </form>
+  </section>
+</div>
+
+<script type="module" src="${pageContext.request.contextPath}/resources/js/member/mypage.js"></script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/rooms/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/detail.jsp
@@ -221,8 +221,6 @@
     </div>
 </div>
 
-<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoJsKey}"></script>
-
 <script type="module" src="${pageContext.request.contextPath}/resources/js/common/apiClient.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomDetail.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>

--- a/src/main/webapp/WEB-INF/views/rooms/map.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/map.jsp
@@ -122,7 +122,9 @@
 </div><!-- /.page-container -->
 
 <!-- Kakao Map JS SDK -->
-<script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoJsKey}&libraries=clusterer"></script>
+<script
+type="text/javascript"
+src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=${kakaoJsKey}&libraries=clusterer"></script>
 
 <!-- 분리된 JS (ES Module) -->
 <script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomMap.js"></script>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -60,6 +60,15 @@
             <param-value>/WEB-INF/dispatcher-servlet.xml</param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
+
+        <multipart-config>
+            <!-- 업로드 가능한 최대 파일 크기 (byte 단위, 10MB 예시) -->
+            <max-file-size>10485760</max-file-size>
+            <!-- 한 요청에서 모든 파일 합친 크기 (20MB 예시) -->
+            <max-request-size>20971520</max-request-size>
+            <!-- 메모리에 보관할 임계값 (그 이상은 디스크로) -->
+            <file-size-threshold>0</file-size-threshold>
+        </multipart-config>
 	</servlet>
 
     <servlet-mapping>

--- a/src/main/webapp/resources/css/common/header.css
+++ b/src/main/webapp/resources/css/common/header.css
@@ -1,0 +1,84 @@
+/* /resources/css/common/header.css */
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 40px;
+  border-bottom: 1px solid #eee;
+  background-color: #fff;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.logo {
+  font-size: 20px;
+  font-weight: 700;
+  text-decoration: none;
+  color: #111;
+}
+
+.gnb {
+  list-style: none;
+  display: flex;
+  gap: 18px;
+  margin: 0;
+  padding: 0;
+}
+
+.gnb a {
+  text-decoration: none;
+  color: #222;
+  font-size: 14px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-icon-btn {
+  position: relative;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  padding: 1px 4px;
+  border-radius: 999px;
+  background-color: #111827;
+  color: #fff;
+  font-size: 10px;
+  text-align: center;
+}
+
+.header-text-btn {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+}
+
+.header-profile {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.header-username {
+  text-decoration: none;
+  color: #111;
+}

--- a/src/main/webapp/resources/css/login.css
+++ b/src/main/webapp/resources/css/login.css
@@ -204,3 +204,40 @@
     display: none;
   }
 }
+  /* ===========================
+   * 회원가입 프로필 사진 영역
+   * =========================== */
+  .register-profile-photo-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 20px;
+  }
+
+  /* 동그란 프로필 사진 */
+  .register-profile-photo {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;        /* 동그라미 핵심 */
+    object-fit: cover;         /* 이미지 비율 유지 + 꽉 채우기 */
+    border: 2px solid #e5e7eb; /* 연한 회색 테두리 */
+    background-color: #f3f4f6; /* 백그라운드 (이미지 없을 때) */
+  }
+
+  /* 사진 추가 버튼 */
+  .btn-regphoto-upload {
+    padding: 6px 14px;
+    border-radius: 999px;      /* 알약 모양 버튼 */
+    border: 1px solid #d1d5db;
+    background-color: #ffffff;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .btn-regphoto-upload:hover {
+    background-color: #f3f4f6;
+    border-color: #9ca3af;
+  }
+

--- a/src/main/webapp/resources/css/member/mypage.css
+++ b/src/main/webapp/resources/css/member/mypage.css
@@ -1,0 +1,234 @@
+/* ===== 공통 ===== */
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Pretendard", "Noto Sans KR", sans-serif;
+  background-color: #f5f6f8;
+  color: #222;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+/* ===== 전체 레이아웃 ===== */
+.mypage-container {
+  max-width: 1200px;
+  margin: 40px auto;
+  padding: 0 20px;
+  display: grid;
+  grid-template-columns: 380px 1fr;
+  gap: 32px;
+}
+
+/* ===== 왼쪽 프로필 카드 ===== */
+.profile-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+  position: sticky;
+  top: 80px;
+}
+
+/* 프로필 사진 감싸는 래퍼: 이미지 + 버튼 세로로 배치 */
+.profile-photo-wrapper {
+  margin: 0 auto 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+/* 실제 동그란 프로필 이미지 */
+.profile-photo {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #ddd;
+}
+
+/* 메인 정보 */
+.profile-main-info {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.profile-main-info h2 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.profile-email,
+.profile-phone {
+  margin: 4px 0;
+  font-size: 13px;
+  color: #666;
+}
+
+/* 태그 */
+.profile-tags {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.profile-tags .tag {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3b5bdb;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* 서브 섹션 */
+.profile-subsection {
+  margin-top: 20px;
+}
+
+.profile-subsection h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+/* 칩 리스트 */
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 6px 12px;
+  background-color: #f1f3f5;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.chip-empty {
+  font-size: 12px;
+  color: #aaa;
+}
+
+/* ===== 오른쪽 수정 폼 ===== */
+.mypage-right {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 28px 32px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+}
+
+.mypage-right h2 {
+  margin: 0 0 24px;
+  font-size: 22px;
+  font-weight: 800;
+}
+
+/* ===== 폼 ===== */
+.form-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+
+.form-row label {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: #444;
+}
+
+.form-row input,
+.form-row select {
+  height: 44px;
+  padding: 0 12px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.form-row input:focus,
+.form-row select:focus {
+  border-color: #4dabf7;
+  box-shadow: 0 0 0 3px rgba(77, 171, 247, 0.15);
+}
+
+/* 체크박스 그룹 */
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f1f3f5;
+  font-size: 13px;
+}
+
+.checkbox-item input {
+  cursor: pointer;
+}
+
+/* ===== 하단 액션 ===== */
+.form-actions {
+  margin-top: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.form-error {
+  color: #e03131;
+  font-size: 13px;
+}
+
+/* 저장 버튼 */
+.btn-primary {
+  height: 46px;
+  padding: 0 28px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #4c6ef5, #364fc7);
+  color: white;
+  font-size: 15px;
+  font-weight: 700;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(76, 110, 245, 0.3);
+}
+
+.btn-primary:active {
+  transform: scale(0.98);
+}
+
+/* ===== 반응형 ===== */
+@media (max-width: 1024px) {
+  .mypage-container {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-card {
+    position: static;
+  }
+}

--- a/src/main/webapp/resources/js/auth/login.js
+++ b/src/main/webapp/resources/js/auth/login.js
@@ -9,7 +9,7 @@ import {
 } from "../common/authTokenStorage.js";
 import { apiRequest } from "../common/apiClient.js";
 
-  // ✅ 페이지 진입 시 accessToken 만료되어 있으면 refreshToken으로 자동 재발급 시도
+  // 페이지 진입 시 accessToken 만료되어 있으면 refreshToken으로 자동 재발급 시도
   async function syncAuthOnPageLoad() {
     const accessToken = getAccessToken();
     const refreshToken = getRefreshToken();
@@ -37,79 +37,15 @@ import { apiRequest } from "../common/apiClient.js";
   }
 
 document.addEventListener("DOMContentLoaded", async () => {
-  // ✅ 1) 우선 accessToken 이 만료돼 있으면 여기서 refresh 시도
+  // 1) 우선 accessToken 이 만료돼 있으면 여기서 refresh 시도
   await syncAuthOnPageLoad();
-   // ✅ 2) 그 다음부터는 항상 "최신 accessToken 기준"으로 로그인 상태 판단
+   // 2) 그 다음부터는 항상 "최신 accessToken 기준"으로 로그인 상태 판단
   setupTabs();
   setupLoginForm();
   setupRegisterForm();
   loadFormCodes();
-
-  //헤더 버튼 로그인/로그아웃 상태 반영
-  setupHeaderAuthButtons();
-
-  // 전역에서 모달 열고 닫을 수 있게
-  window.openAuthModal = openAuthModal;
-  window.closeAuthModal = closeAuthModal;
+  setupRegisterPhotoUpload();
 });
-
-function setupHeaderAuthButtons() {
-  const loginBtn    = document.getElementById("btnOpenLogin");
-  const registerBtn = document.getElementById("btnOpenRegister");
-  const logoutBtn   = document.getElementById("btnLogout");
-
-  // 헤더가 없는 페이지면 그냥 리턴
-  if (!loginBtn || !logoutBtn) return;
-
-  const hasToken = !!getAccessToken();
-
-  if (hasToken) {
-    // ✅ 로그인 상태 → 로그아웃만 보이게
-    loginBtn.style.display = "none";
-    if (registerBtn) registerBtn.style.display = "none";
-    logoutBtn.style.display = "inline-block";
-  } else {
-    // ✅ 비로그인 상태 → 로그인 / 회원가입 표시
-    loginBtn.style.display = "inline-block";
-    if (registerBtn) registerBtn.style.display = "inline-block";
-    logoutBtn.style.display = "none";
-  }
-
-  // ▶ 로그인 버튼: 로그인 탭을 열면서 모달 띄우기
-  loginBtn.onclick = () => {
-    openAuthModal("login");
-  };
-
-  // ▶ 회원가입 버튼: 회원가입 탭을 열면서 모달 띄우기
-  if (registerBtn) {
-    registerBtn.onclick = () => {
-      openAuthModal("register");
-    };
-  }
-
-  // ▶ 로그아웃 버튼
-  logoutBtn.onclick = async () => {
-    try {
-      const accessToken = getAccessToken();
-      const tokenType = getTokenType() || "Bearer";
-
-      if (accessToken) {
-        await fetch("/api/auth/logout", {
-          method: "POST",
-          headers: {
-            Authorization: `${tokenType} ${accessToken}`,
-          },
-        });
-      }
-    } catch (err) {
-      console.error("logout error:", err);
-    } finally {
-      // 어쨌든 토큰은 지우고 새로고침
-      clearTokens();
-      location.reload();
-    }
-  };
-}
 
 
 /* =====================
@@ -147,6 +83,9 @@ function closeAuthModal() {
   if (!modal) return;
   modal.classList.add("hidden");
 }
+
+window.openAuthModal = openAuthModal;
+window.closeAuthModal = closeAuthModal;
 
 /* =====================
  *  탭 전환 (로그인 / 회원가입)
@@ -233,18 +172,11 @@ function setupLoginForm() {
         return;
       }
 
-      // saveTokens가 객체를 받는지 / 개별 인자를 받는지 모를 때 안전하게 처리
-      if (saveTokens.length >= 2) {
-        // (accessToken, refreshToken, tokenType) 방식
-        saveTokens(accessToken, refreshToken, tokenType || "Bearer");
-      } else {
-        // ({ accessToken, refreshToken, tokenType }) 방식
         saveTokens({
           accessToken,
           refreshToken,
           tokenType: tokenType || "Bearer",
         });
-      }
 
       closeAuthModal();
       // 로그인 후 원하는 곳으로 이동
@@ -257,6 +189,68 @@ function setupLoginForm() {
   });
 }
 
+/* =====================
+ *  회원가입 - 프로필 사진 파일 선택 + 미리보기
+ * ===================== */
+function setupRegisterPhotoUpload() {
+  const fileInput = document.getElementById("regPhotoFileInput");
+  const uploadBtn = document.getElementById("btnRegPhotoUpload");
+  const previewImg = document.getElementById("regProfilePhoto");
+  const tempIdInput = document.getElementById("regProfileTempFileId");
+
+  // 요소 중 하나라도 없으면 안전하게 종료
+  if (!fileInput || !uploadBtn || !previewImg) {
+    return;
+  }
+
+  // 버튼 클릭 → 숨겨진 file input 클릭
+  uploadBtn.addEventListener("click", () => {
+    fileInput.click();
+  });
+
+  // 파일 선택 → 이미지 미리보기
+  fileInput.addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    // 간단 이미지 타입 체크 (선택사항)
+    if (!file.type.startsWith("image/")) {
+      alert("이미지 파일만 선택할 수 있습니다.");
+      fileInput.value = "";
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await fetch("/api/files/temp/profile", {
+        method: "PUT",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        alert("프로필 이미지 업로드에 실패했습니다.");
+        return;
+      }
+
+      const data = await res.json();
+      // 백엔드 TempUploadFileResponse: temp_file_id, temp_url
+      const tempFileId = data.temp_file_id;
+      const tempUrl    = data.temp_url;
+
+      // 1) hidden input에 temp_file_id 저장 → 회원가입 submit 때 같이 보냄
+      tempIdInput.value = tempFileId;
+
+      // 2) 미리보기 이미지 변경
+      previewImg.src = tempUrl;
+
+    } catch (err) {
+      console.error("temp profile upload error:", err);
+      alert("이미지 업로드 중 오류가 발생했습니다.");
+    }
+  });
+}
 /* =====================
  *  회원가입 처리
  * ===================== */
@@ -281,16 +275,19 @@ async function handleRegisterSubmit(e) {
   const workTypeSelect = document.getElementById("regWorkType");
   const workTypeRaw = workTypeSelect.value;
   const mbti = document.getElementById("regMbti").value || null;
-  const photoUrl = document.getElementById("regPhoto").value.trim();
-  const registerError = document.getElementById("registerError");
 
+  // 🔹 숨겨진 tempFileId
+  const profileTempFileIdVal = document.getElementById("regProfileTempFileId").value;
+  const profileTempFileId = profileTempFileIdVal ? Number(profileTempFileIdVal) : null;
+
+  const registerError = document.getElementById("registerError");
   registerError.textContent = "";
 
   if (password !== confirm) {
     registerError.textContent = "비밀번호가 일치하지 않습니다.";
     return;
   }
-  // 🔥 workTypeId 필수 체크 (DTO @NotNull)
+  // workTypeId 필수 체크 (DTO @NotNull)
   if (!workTypeRaw) {
     registerError.textContent = "직업/라이프스타일을 선택해주세요.";
     return;
@@ -310,28 +307,31 @@ async function handleRegisterSubmit(e) {
     document.querySelectorAll(".pet-checkbox:checked")
   ).map((el) => Number(el.value));
 
-  // ⚠️ 여기부터는 백엔드 SignUpRequest 필드 이름(camelCase)에 맞춘다
+  // 여기부터는 백엔드 SignUpRequest 필드 이름(camelCase)에 맞춘다
   const payload = {
     email,
     password,
     name,
     phone,
 
-    // 자바: photoUrl  → JSON: photo_url
-    photo_url,//: photoUrl || null,
-
     // 자바: sleepTime → JSON: sleep_time
-    sleep_time,//: sleepTime,     // String
+    sleep_time : sleepTime,     // String
     // 자바: workTypeId → JSON: work_type_id
-    work_type_id,//: workTypeId,  // Long or null
+    work_type_id : workTypeId,  // Long or null
     smoking,                   // MemberSmokingEnum (NON_SMOKER / SMOKER)
     drinking,                  // MemberDrinkingEnum (NONE / SOCIAL / OFTEN)
     mbti,                      // String or null
 
     // 자바: hobbyIds → JSON: hobby_ids
-    hobby_ids,//: hobbyIds,
-    preference_ids,//: preferenceIds,
+    hobby_ids : hobbyIds,
+    preference_ids : preferenceIds,
     pet_ids: petIds,
+
+    // 🔹 임시 파일 ID 전달 (SignUpRequest.profileTempFileId)
+    profile_temp_file_id: profileTempFileId,
+
+    // 🔹 temp 파일을 쓰는 경우 photo_url은 null로
+    photo_url: profileTempFileId ? null : (photoUrl || null),
   };
 
   try {

--- a/src/main/webapp/resources/js/common/apiClient.js
+++ b/src/main/webapp/resources/js/common/apiClient.js
@@ -18,13 +18,20 @@ function sleep(ms) {
 export async function apiRequest(input, init = {}) {
   // 1) 기존 옵션 복사
   const options = { ...init };
+
+  const isFormData = options.body instanceof FormData;
+
   options.headers = {
     ...(init.headers || {}),
-    "Content-Type":
+  };
+
+  if(!isFormData) {
+    options.headers["Content-Type"] =
       init.headers && init.headers["Content-Type"]
         ? init.headers["Content-Type"]
-        : "application/json",
-  };
+        : "application/json";
+  }
+
 
   const accessToken = getAccessToken();
   if (accessToken) {
@@ -45,9 +52,15 @@ export async function apiRequest(input, init = {}) {
     // RefreshToken도 없으면 그냥 로그아웃 처리
     clearTokens();
     alert("로그인이 만료되었습니다. 다시 로그인 해주세요.");
+
+    if(typeof window.openAuthModal == "function") {
+        window.openAuthModal("login");
+    }
     // 필요하면 location.href = "/login"; 이런 거 추가
     return response;
   }
+
+
 
   // 2) Refresh 요청
   const refreshResponse = await fetch("/api/auth/refresh", {
@@ -56,7 +69,7 @@ export async function apiRequest(input, init = {}) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      refreshToken: refreshToken,
+      refresh_token: refreshToken,
     }),
   });
 
@@ -64,6 +77,9 @@ export async function apiRequest(input, init = {}) {
     // refresh 실패 → 토큰 삭제 후 로그인 페이지로 유도
     clearTokens();
     alert("세션이 만료되었습니다. 다시 로그인 해주세요.");
+    if (typeof window.openAuthModal === "function") {
+      window.openAuthModal("login");
+    }
     return response;
   }
 
@@ -71,16 +87,16 @@ export async function apiRequest(input, init = {}) {
 
   // 응답 필드 이름은 서버 snake_case 기준
   saveTokens({
-    accessToken: refreshData.accessToken,
-    refreshToken: refreshData.refreshToken,
-    tokenType: refreshData.tokenType,
+    accessToken: refreshData.access_token,
+    refreshToken: refreshData.refresh_token,
+    tokenType: refreshData.token_type,
   });
 
   // 🔁 새 AccessToken으로 원래 요청 다시 한번 시도
   const retryOptions = { ...options };
   retryOptions.headers = {
     ...(options.headers || {}),
-    Authorization: `${refreshData.tokenType} ${refreshData.accessToken}`,
+    Authorization: `${refreshData.token_type} ${refreshData.access_token}`,
   };
 
   const retryResponse = await fetch(input, retryOptions);

--- a/src/main/webapp/resources/js/common/authGuard.js
+++ b/src/main/webapp/resources/js/common/authGuard.js
@@ -1,7 +1,7 @@
 // /resources/js/common/authGuard.js
 // 로그인 필요 기능에서 공통으로 쓰는 유틸
 
-import { getAccessToken } from "/resources/js/common/authTokenStorage.js";
+import { getAccessToken } from "../common/authTokenStorage.js";
 
 /**
  * 로그인 여부 체크
@@ -13,12 +13,13 @@ export function requireLogin() {
 
   // 비로그인 상태
   if (!token) {
+    alert("로그인이 필요한 서비스입니다.");
     // login.js 에서 전역으로 등록해둔 openAuthModal 사용
     if (typeof window.openAuthModal === "function") {
       window.openAuthModal("login"); // 기본 탭을 로그인으로
     } else {
       // 혹시 모달 스크립트가 아직 안 올라온 경우 대비
-      alert("로그인이 필요한 서비스입니다.");
+       console.warn("openAuthModal 이 아직 준비가 안 됐어요.");
     }
     return false;
   }

--- a/src/main/webapp/resources/js/common/header.js
+++ b/src/main/webapp/resources/js/common/header.js
@@ -1,0 +1,73 @@
+import {
+  getAccessToken,
+  clearTokens,
+} from "../common/authTokenStorage.js";
+import { apiRequest } from "../common/apiClient.js";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const authButtons   = document.getElementById("headerAuthButtons");
+  const profileArea   = document.getElementById("headerProfileArea");
+  const headerUsername = document.getElementById("headerUsername");
+  const btnLogout     = document.getElementById("btnLogout");
+  const btnOpenLogin  = document.getElementById("btnOpenLogin");
+  const btnOpenRegister = document.getElementById("btnOpenRegister");
+
+  // 로그인/회원가입 버튼 클릭 → 모달 열기
+  if (btnOpenLogin) {
+    btnOpenLogin.addEventListener("click", () => {
+      window.openAuthModal && window.openAuthModal("login");
+    });
+  }
+  if (btnOpenRegister) {
+    btnOpenRegister.addEventListener("click", () => {
+      window.openAuthModal && window.openAuthModal("register");
+    });
+  }
+
+  const token = getAccessToken();
+  if (!token) {
+    // 비로그인
+    authButtons && (authButtons.style.display = "flex");
+    profileArea && (profileArea.style.display = "none");
+    return;
+  }
+
+  try {
+    const res = await apiRequest("/api/members/me", { method: "GET" });
+    if (!res.ok) throw new Error();
+
+    const data = await res.json();
+    const name = data.name || "";
+    const email = data.email || "";
+    const handle =
+      email && email.includes("@")
+        ? email.split("@")[0]
+        : name || "user";
+
+    if (headerUsername) headerUsername.textContent = handle;
+
+    authButtons && (authButtons.style.display = "none");
+    profileArea && (profileArea.style.display = "flex");
+  } catch (e) {
+    // 토큰 이상 → 비로그인 처리
+    clearTokens();
+    authButtons && (authButtons.style.display = "flex");
+    profileArea && (profileArea.style.display = "none");
+  }
+
+  if (btnLogout) {
+    btnLogout.addEventListener("click", async () => {
+      const ok = confirm("로그아웃 하시겠습니까?");
+      if (!ok) return;
+
+      try {
+        await apiRequest("/api/auth/logout", { method: "POST" });
+      } catch (e) {
+        console.error(e);
+      } finally {
+        clearTokens();
+        location.reload();
+      }
+    });
+  }
+});

--- a/src/main/webapp/resources/js/member/mypage.js
+++ b/src/main/webapp/resources/js/member/mypage.js
@@ -1,0 +1,371 @@
+// /resources/js/member/mypage.js
+
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  // 1) 비로그인 → 로그인 모달 열고 종료
+  const ok = requireLogin();
+  if (!ok) {
+    return;
+  }
+
+  try {
+    // 2) 코드 먼저 로딩 → 셀렉트/체크박스 채우기
+    await loadFormCodesForMypage();
+    // 3) 내 프로필 정보 로딩 → 값 채우기
+    await loadMyProfile();
+    // 4) 폼 submit 이벤트 등록
+    setupMypageFormSubmit();
+  } catch (e) {
+    console.error("mypage init error:", e);
+    const errSpan = document.getElementById("mypageError");
+    if (errSpan) {
+      errSpan.textContent = "마이페이지 정보를 불러오는 중 오류가 발생했습니다.";
+    }
+  }
+});
+document.getElementById("photoFileInput")?.addEventListener("change",async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+        const res = await apiRequest("/api/members/me/photo", {
+            method: "PUT",
+            body: formData,
+        });
+
+        if(!res.ok) {
+            alert("프로필 사진 업로드에 실패했습니다");
+            return;
+        }
+
+        const data = await res.json();
+
+        const profilePhoto = document.getElementById("profilePhoto");
+        if (profilePhoto) {
+            profilePhoto.src = data.photo_url || data.photoUrl;
+        }
+
+        alert("프로필 사진이 변경되었습니다.");
+    } catch (err) {
+      console.error("photo upload error:", err);
+      alert("서버 오류가 발생했습니다.");
+    }
+});
+/**
+ * 직업/취미/선호/반려동물 코드 로딩해서 마이페이지 폼에 렌더링
+ */
+async function loadFormCodesForMypage() {
+  const workTypeSelect = document.getElementById("mpWorkType");
+  const hobbyContainer = document.getElementById("mpHobbyCheckboxList");
+  const prefContainer = document.getElementById("mpPreferenceCheckboxList");
+  const petContainer = document.getElementById("mpPetCheckboxList");
+
+  if (!workTypeSelect || !hobbyContainer || !prefContainer || !petContainer) {
+    return;
+  }
+
+  const res = await apiRequest("/api/members/form-codes", { method: "GET" });
+  if (!res.ok) {
+    throw new Error("form-codes load failed");
+  }
+
+  const data = await res.json();
+  const { work_types: workTypes, hobbies, preferences, pets } = data;
+
+  // 직업/라이프스타일
+  if (Array.isArray(workTypes)) {
+    workTypes.forEach((wt) => {
+      const opt = document.createElement("option");
+      opt.value = wt.work_type_id;
+      opt.textContent = wt.work_type_name;
+      workTypeSelect.appendChild(opt);
+    });
+  }
+
+  // 취미
+  if (Array.isArray(hobbies)) {
+    hobbies.forEach((hobby) => {
+      const label = document.createElement("label");
+      label.classList.add("checkbox-item");
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.classList.add("hobby-checkbox");
+      checkbox.value = hobby.hobby_id;
+
+      const span = document.createElement("span");
+      span.textContent = hobby.hobby_name;
+
+      label.appendChild(checkbox);
+      label.appendChild(span);
+      hobbyContainer.appendChild(label);
+    });
+  }
+
+  // 생활 선호
+  if (Array.isArray(preferences)) {
+    preferences.forEach((pref) => {
+      const label = document.createElement("label");
+      label.classList.add("checkbox-item");
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.classList.add("preference-checkbox");
+      checkbox.value = pref.preference_id;
+
+      const span = document.createElement("span");
+      span.textContent = pref.preference_name;
+
+      label.appendChild(checkbox);
+      label.appendChild(span);
+      prefContainer.appendChild(label);
+    });
+  }
+
+  // 반려동물
+  if (Array.isArray(pets)) {
+    pets.forEach((pet) => {
+      const label = document.createElement("label");
+      label.classList.add("checkbox-item");
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.classList.add("pet-checkbox");
+      checkbox.value = pet.pet_id;
+
+      const span = document.createElement("span");
+      span.textContent = pet.pet_name;
+
+      label.appendChild(checkbox);
+      label.appendChild(span);
+      petContainer.appendChild(label);
+    });
+  }
+}
+
+/**
+ * /api/members/me 로 내 정보 조회해서
+ *  - 왼쪽 프로필 카드
+ *  - 오른쪽 수정 폼
+ *   에 값 채워 넣기
+ */
+async function loadMyProfile() {
+  const res = await apiRequest("/api/members/me", { method: "GET" });
+  if (!res.ok) {
+    throw new Error("failed to load /api/members/me");
+  }
+
+  const data = await res.json();
+
+  // ----- 왼쪽 프로필 카드 -----
+  const profileName = document.getElementById("profileName");
+  const profileEmail = document.getElementById("profileEmail");
+  const profilePhone = document.getElementById("profilePhone");
+  const profilePhoto = document.getElementById("profilePhoto");
+  const profileWorkType = document.getElementById("profileWorkType");
+  const profileMbti = document.getElementById("profileMbti");
+  const profileSmoking = document.getElementById("profileSmoking");
+  const profileDrinking = document.getElementById("profileDrinking");
+  const profileSleepTime = document.getElementById("profileSleepTime");
+  const profileHobbies = document.getElementById("profileHobbies");
+  const profilePreferences = document.getElementById("profilePreferences");
+  const profilePets = document.getElementById("profilePets");
+
+  profileName && (profileName.textContent = data.name || "");
+  profileEmail && (profileEmail.textContent = data.email || "");
+  profilePhone && (profilePhone.textContent = data.phone || "");
+
+  if (profilePhoto) {
+    const url = data.photo_url || data.photoUrl || "";
+    profilePhoto.src = url || "/resources/img/default-profile.png";
+  }
+
+  if (profileWorkType) {
+    profileWorkType.textContent = data.work_type_name || "직업/라이프스타일 미설정";
+  }
+  if (profileMbti) {
+    profileMbti.textContent = data.mbti ? `MBTI: ${data.mbti}` : "MBTI 미설정";
+  }
+  if (profileSmoking) {
+    profileSmoking.textContent = data.smoking === "SMOKER" ? "흡연" : "비흡연";
+  }
+  if (profileDrinking) {
+    let drinkLabel = "음주 미설정";
+    if (data.drinking === "NONE") drinkLabel = "음주 안함";
+    if (data.drinking === "SOCIAL") drinkLabel = "가끔 마심";
+    if (data.drinking === "OFTEN") drinkLabel = "자주 마심";
+    profileDrinking.textContent = drinkLabel;
+  }
+  if (profileSleepTime) {
+    const raw = data.sleep_time || data.sleepTime;
+    let label = "수면 시간 미설정";
+
+    if (raw === "EARLY")  label = "일찍 잠 (22시 이전)";
+    if (raw === "NORMAL") label = "보통 (22~24시)";
+    if (raw === "LATE")   label = "늦게 잠 (자정 이후)";
+
+    profileSleepTime.textContent = label;
+  }
+  // chip list 렌더링 헬퍼
+  function renderChips(container, items, labelKey) {
+    if (!container) return;
+    container.innerHTML = "";
+    if (!Array.isArray(items) || items.length === 0) {
+      const span = document.createElement("span");
+      span.classList.add("chip-empty");
+      span.textContent = "없음";
+      container.appendChild(span);
+      return;
+    }
+    items.forEach((item) => {
+      const chip = document.createElement("span");
+      chip.classList.add("chip");
+      chip.textContent = item[labelKey];
+      container.appendChild(chip);
+    });
+  }
+
+  renderChips(profileHobbies, data.hobbies || [], "hobby_name");
+  renderChips(profilePreferences, data.preferences || [], "preference_name");
+  renderChips(profilePets, data.pets || [], "pet_name");
+
+  // ----- 오른쪽 수정 폼 값 세팅 -----
+  const mpName = document.getElementById("mpName");
+  const mpPhone = document.getElementById("mpPhone");
+  const mpWorkType = document.getElementById("mpWorkType");
+  const mpSleepTime = document.getElementById("mpSleepTime");
+  const mpSmoking = document.getElementById("mpSmoking");
+  const mpDrinking = document.getElementById("mpDrinking");
+  const mpMbti = document.getElementById("mpMbti");
+
+  mpName && (mpName.value = data.name || "");
+  mpPhone && (mpPhone.value = data.phone || "");
+  if (mpWorkType && (data.work_type_id || data.workTypeId)) {
+    mpWorkType.value = data.work_type_id || data.workTypeId;
+  }
+  mpSleepTime &&
+    (mpSleepTime.value = data.sleep_time || data.sleepTime || "");
+  mpSmoking && (mpSmoking.value = data.smoking || "NON_SMOKER");
+  mpDrinking && (mpDrinking.value = data.drinking || "NONE");
+  mpMbti && (mpMbti.value = data.mbti || "");
+
+  // 취미/선호/펫 체크박스 체크 상태 반영
+  const hobbyIds = (data.hobbies || []).map((h) => h.hobby_id);
+  const preferenceIds = (data.preferences || []).map(
+    (p) => p.preference_id
+  );
+  const petIds = (data.pets || []).map((p) => p.pet_id);
+
+  document
+    .querySelectorAll("#mpHobbyCheckboxList .hobby-checkbox")
+    .forEach((cb) => {
+      const id = Number(cb.value);
+      cb.checked = hobbyIds.includes(id);
+    });
+
+  document
+    .querySelectorAll("#mpPreferenceCheckboxList .preference-checkbox")
+    .forEach((cb) => {
+      const id = Number(cb.value);
+      cb.checked = preferenceIds.includes(id);
+    });
+
+  document
+    .querySelectorAll("#mpPetCheckboxList .pet-checkbox")
+    .forEach((cb) => {
+      const id = Number(cb.value);
+      cb.checked = petIds.includes(id);
+    });
+}
+
+/**
+ * 폼 submit → PUT /api/members/me
+ */
+function setupMypageFormSubmit() {
+  const form = document.getElementById("mypageForm");
+  const errorSpan = document.getElementById("mypageError");
+  if (!form) return;
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    if (errorSpan) errorSpan.textContent = "";
+
+    const name = document.getElementById("mpName").value.trim();
+    const phone = document.getElementById("mpPhone").value.trim();
+    const workTypeRaw = document.getElementById("mpWorkType").value;
+    const sleepTime = document.getElementById("mpSleepTime").value || null;
+    const smoking = document.getElementById("mpSmoking").value;
+    const drinking = document.getElementById("mpDrinking").value;
+    const mbti = document.getElementById("mpMbti").value || null;
+
+    const hobbyIds = Array.from(
+      document.querySelectorAll(
+        "#mpHobbyCheckboxList .hobby-checkbox:checked"
+      )
+    ).map((el) => Number(el.value));
+    const preferenceIds = Array.from(
+      document.querySelectorAll(
+        "#mpPreferenceCheckboxList .preference-checkbox:checked"
+      )
+    ).map((el) => Number(el.value));
+    const petIds = Array.from(
+      document.querySelectorAll(
+        "#mpPetCheckboxList .pet-checkbox:checked"
+      )
+    ).map((el) => Number(el.value));
+
+    const workTypeId = workTypeRaw ? Number(workTypeRaw) : null;
+
+    // MemberProfileUpdateRequest + SnakeCase 기준 payload
+    const payload = {
+      name,
+      phone,
+      work_type_id: workTypeId,
+      sleep_time: sleepTime,
+      smoking,
+      drinking,
+      mbti,
+      hobby_ids: hobbyIds,
+      preference_ids: preferenceIds,
+      pet_ids: petIds,
+    };
+
+    try {
+      const res = await apiRequest("/api/members/me", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        let message = "프로필 수정에 실패했습니다.";
+        try {
+          const errBody = await res.json();
+          if (errBody && errBody.message) {
+            message = errBody.message;
+          }
+        } catch (_) {}
+        if (errorSpan) errorSpan.textContent = message;
+        return;
+      }
+        console.log("mbti value before send:", document.getElementById("mpMbti").value);
+        console.log("payload:", payload);
+
+      alert("프로필이 수정되었습니다.");
+      // 수정 후 최신 데이터 다시 로딩
+      await loadMyProfile();
+    } catch (err) {
+      console.error("update profile error:", err);
+      if (errorSpan) {
+        errorSpan.textContent = "서버 오류가 발생했습니다.";
+      }
+    }
+  });
+}

--- a/src/main/webapp/resources/js/room/roomDetail.js
+++ b/src/main/webapp/resources/js/room/roomDetail.js
@@ -1,6 +1,6 @@
 // /resources/js/room/roomDetail.js
-import { apiRequest } from "/resources/js/common/apiClient.js";
-import { requireLogin } from "/resources/js/common/authGuard.js";
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
 
 // 숫자 3자리 콤마
 function formatNumber(num) {

--- a/src/main/webapp/resources/js/room/roomMap.js
+++ b/src/main/webapp/resources/js/room/roomMap.js
@@ -1,6 +1,6 @@
 // ES Module
-import { apiRequest } from "/resources/js/common/apiClient.js";
-import { requireLogin } from "/resources/js/common/authGuard.js";
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
 
 let map;
 let clusterer;
@@ -63,8 +63,8 @@ window.addEventListener("load", () => {
   if (!requireLogin()) {
     return;
   }
-
-  window.location.href = "/rooms/" + selectedRoomId;
+  const contextPath = window.contextPath || "";
+  window.location.href = `${contextPath}/rooms/${selectedRoomId}`;
 });
 
   // 찜하기 (나중에 /api/favorites 연결 예정)


### PR DESCRIPTION
##  작업 내용
- 마이페이지(/mypage) V1 구현
- 내 정보 조회: GET /api/members/me
- 내 정보 수정: PUT /api/members/me
- 프로필 사진 업로드 / 교체 기능 추가
- 헤더에 마이페이지 메뉴 추가 (로그인 시에만 노출)
- 비로그인 상태에서 마이페이지 접근 시 로그인 모달 호출
- 회원가입 프로필 임시 업로드(temp 파일) 구조 추가

##  주요 변경 파일
- members/mypage.jsp
- member/mypage.css
- member/mypage.js
- MemberService, MemberRestController
- TempUploadFile 도메인 전체 추가

##  테스트 체크리스트
- [x] 비로그인 시 마이페이지 접근 → 로그인 모달 호출
- [x] 로그인 후 마이페이지 진입 가능
- [x] 정보 수정 후 정상 반영
- [x] 프로필 사진 변경 정상 반영
- [x] 회원가입 시 임시 파일 → 실제 프로필 저장

##  비고
- 마이페이지 V1 기준이며, 비밀번호 변경/회원 탈퇴 UI는 후속 PR 예정
