### PR TITLE
feat: 마이페이지 비밀번호 변경 및 프로필 수정 분리 구현

### DIFF
--- a/src/main/java/com/roommate/common/exception/ErrorCode.java
+++ b/src/main/java/com/roommate/common/exception/ErrorCode.java
@@ -20,6 +20,11 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A007", "리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_REUSED(HttpStatus.UNAUTHORIZED, "A008", "이미 사용된 리프레시 토큰입니다."),
 
+    // 비밀번호 검증 관련
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "P001", "현재 비밀번호가 일치하지 않습니다."),
+    PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "P002", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "P003", "이전 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+
     // ===== ADMIN / 관리자 관련 =====
     ADMIN_ONLY(HttpStatus.FORBIDDEN, "AD001", "관리자만 접근할 수 있습니다."),
     ADMIN_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AD002", "관리 대상 회원이 존재하지 않습니다."),

--- a/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberRestController.java
@@ -1,9 +1,11 @@
 package com.roommate.domain.member.controller;
 
 import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.member.dto.request.MemberPasswordChangeRequest;
 import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
+import com.roommate.domain.member.dto.response.PasswordChangeResponse;
 import com.roommate.domain.member.dto.response.WorkTypeResponse;
 import com.roommate.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -65,5 +67,11 @@ public class MemberRestController {
     public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.deleteMember(userDetails.getMemberId());
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/me/password")
+    public ResponseEntity<PasswordChangeResponse> changeMyPassword(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody MemberPasswordChangeRequest memberPasswordChangeRequest) {
+        memberService.changeMyPassword(userDetails.getMemberId(), memberPasswordChangeRequest);
+        return ResponseEntity.ok(new PasswordChangeResponse("비밀번호가 성공적으로 변경되었습니다."));
     }
 }

--- a/src/main/java/com/roommate/domain/member/controller/MemberViewController.java
+++ b/src/main/java/com/roommate/domain/member/controller/MemberViewController.java
@@ -6,13 +6,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("members")
+@RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberViewController {
 
     @GetMapping("/mypage")
-    public String mypage() {
-        // /WEB-INF/views/members/mypage.jsp 를 의미
-        return "members/mypage";
+    public String mypageMain() {
+        // 프로필 요약 + 탭 + "프로필 수정" 버튼
+        return "members/mypage";          // /WEB-INF/views/members/mypage.jsp
+    }
+
+    @GetMapping("/mypage/edit")
+    public String mypageEdit() {
+        // 실제 수정 폼 화면
+        return "members/mypageEdit";     // /WEB-INF/views/members/mypageEdit.jsp
     }
 }

--- a/src/main/java/com/roommate/domain/member/dto/request/MemberPasswordChangeRequest.java
+++ b/src/main/java/com/roommate/domain/member/dto/request/MemberPasswordChangeRequest.java
@@ -1,0 +1,22 @@
+package com.roommate.domain.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberPasswordChangeRequest {
+
+    @NotBlank
+    private String currentPassword;
+    @NotBlank
+    @Size(min = 8 , max = 64)
+    private String newPassword;
+    @NotBlank
+    private String confirmPassword;
+}

--- a/src/main/java/com/roommate/domain/member/dto/response/PasswordChangeResponse.java
+++ b/src/main/java/com/roommate/domain/member/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,13 @@
+package com.roommate.domain.member.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class PasswordChangeResponse {
+    private String message;
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -25,4 +25,6 @@ public interface MemberRepository {
 
     void softDeleteMember(@Param("memberId") Long memberId);
 
+    void updatePassword(@Param("memberId") Long memberId, @Param("password") String encodedPassword);
+
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberService.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.roommate.domain.member.service;
 
 import java.util.List;
 
+import com.roommate.domain.member.dto.request.MemberPasswordChangeRequest;
 import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.FormCodesResponse;
 import com.roommate.domain.member.dto.response.MemberResponse;
@@ -19,4 +20,6 @@ public interface MemberService {
 	public FormCodesResponse getFormCodes();
 
 	public MemberResponse updateMemberProfilePhoto(Long memberId, MultipartFile multipartFile);
+
+	void changeMyPassword(Long memberId, MemberPasswordChangeRequest memberPasswordChangeRequest);
 }

--- a/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/roommate/domain/member/service/MemberServiceImpl.java
@@ -6,12 +6,14 @@ import com.roommate.domain.auth.repository.TokenRefreshRepository;
 import com.roommate.domain.chat.repository.ChatRoomRepository;
 import com.roommate.domain.favorite.repository.FavoriteRepository;
 import com.roommate.domain.file.service.FileStorageService;
+import com.roommate.domain.member.dto.request.MemberPasswordChangeRequest;
 import com.roommate.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.roommate.domain.member.dto.response.*;
 import com.roommate.domain.member.entity.*;
 import com.roommate.domain.member.repository.*;
 import com.roommate.domain.notification.repository.NotificationRepository;
 import com.roommate.domain.room.repository.RoomRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,8 @@ import java.util.List;
 public class MemberServiceImpl implements MemberService {
 
     private final FileStorageService fileStorageService;
+
+    private final PasswordEncoder passwordEncoder;
 
     private final MemberRepository memberRepository;
     private final WorkTypeRepository workTypeRepository;
@@ -279,5 +283,34 @@ public class MemberServiceImpl implements MemberService {
         List<PetEntity> petEntities = petRepository.findByMemberId(memberId);
 
         return toMemberResponse(memberEntity, workTypeEntity, hobbyEntities, preferenceEntities, petEntities);
+    }
+
+    @Override
+    @Transactional
+    public void changeMyPassword(Long memberId, MemberPasswordChangeRequest memberPasswordChangeRequest) {
+        MemberEntity memberEntity = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (memberEntity.getDeleted() == 1) {
+            throw new ApiException(ErrorCode.MEMBER_DEACTIVATED);
+        }
+
+        if (!memberPasswordChangeRequest.getNewPassword().equals(memberPasswordChangeRequest.getConfirmPassword())) {
+            throw new ApiException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        if (!passwordEncoder.matches(memberPasswordChangeRequest.getCurrentPassword(), memberEntity.getPassword())) {
+            throw new ApiException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        if (passwordEncoder.matches(memberPasswordChangeRequest.getNewPassword(), memberEntity.getPassword())) {
+            throw new ApiException(ErrorCode.PASSWORD_SAME_AS_OLD);
+        }
+
+        String encodeNewPassword = passwordEncoder.encode(memberPasswordChangeRequest.getNewPassword());
+
+        memberRepository.updatePassword(memberId,encodeNewPassword);
+
+        tokenRefreshRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
+++ b/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
@@ -15,7 +15,7 @@ import com.roommate.domain.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 
 @Controller
-@RequestMapping("rooms")
+@RequestMapping("/rooms")
 @RequiredArgsConstructor
 public class RoomViewController {
 

--- a/src/main/resources/mapper/member/Member.xml
+++ b/src/main/resources/mapper/member/Member.xml
@@ -94,10 +94,17 @@
         WHERE
             member_id = #{memberId}
     </update>
-    <!-- resources/mapper/member/Member.xml -->
     <update id="softDeleteMember" parameterType="long">
         UPDATE members
         SET deleted = 1
         WHERE member_id = #{memberId}
+    </update>
+    <!-- 비밀번호 변경 전용 업데이트 -->
+    <update id="updatePassword">
+        UPDATE members
+        SET password = #{password},
+        member_updated_at = CURRENT_TIMESTAMP
+        WHERE member_id = #{memberId}
+        AND deleted = 0
     </update>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/members/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypage.jsp
@@ -1,158 +1,158 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
 <html>
 <head>
-  <title>마이페이지 - Roommate</title>
-  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/member/mypage.css">
+    <title>마이페이지</title>
+    <link rel="stylesheet" href="/resources/css/member/mypage-view.css">
 </head>
 <body>
-
 <jsp:include page="/WEB-INF/views/common/header.jsp" />
 
-<div class="mypage-container">
-  <!-- 왼쪽: 프로필 카드 -->
-  <section class="mypage-left">
-    <div class="profile-card">
-      <div class="profile-photo-wrapper">
-        <img id="profilePhoto" src="" alt="프로필 사진" class="profile-photo">
-        <input type="file" id="photoFileInput" accept="image/*" style="display: none;"/>
-        <button type="button" class="btn-photo-upload" onclick="document.getElementById('photoFileInput').click();">
-        사진 변경
+<main class="mypage-main">
+  <!-- ✅ 상단 프로필 요약 카드 (스샷처럼 가로로 긴 카드) -->
+  <section class="profile-summary-card">
+    <div class="profile-summary-top">
+      <!-- 왼쪽: 프로필 사진 + 사진 변경 버튼 -->
+      <div class="profile-summary-photo">
+        <img id="profilePhoto"
+             src="/resources/img/default-profile.png"
+             alt="프로필 사진"
+             class="profile-photo-lg">
+        <input type="file" id="photoFileInput" accept="image/*" style="display:none;">
+        <button type="button"
+                class="btn-photo-upload"
+                onclick="document.getElementById('photoFileInput').click();">
+          사진 변경
         </button>
       </div>
-      <div class="profile-main-info">
-        <h2 id="profileName">이름</h2>
-        <p id="profileEmail" class="profile-email">email@example.com</p>
-        <p id="profilePhone" class="profile-phone">010-0000-0000</p>
+
+      <!-- 가운데: 이름 / 이메일 / 전화번호 / 가입일 -->
+      <div class="profile-summary-info">
+        <p class="profile-label">내 프로필</p>
+        <h2 id="profileName" class="profile-name">이름</h2>
+        <!-- 필요하면 핸들용 span 하나 더 둘 수도 있음 -->
+        <!-- <p id="profileHandle" class="profile-handle">@username</p> -->
+
+        <div class="profile-contact">
+          <span id="profileEmail" class="profile-contact-item">email@example.com</span>
+          <span id="profilePhone" class="profile-contact-item">010-0000-0000</span>
+          <span id="profileJoinedAt" class="profile-contact-item">가입일: 2024. 1. 1.</span>
+        </div>
       </div>
 
-      <div class="profile-tags">
-        <span class="tag" id="profileWorkType">직업/라이프스타일</span>
-        <span class="tag" id="profileMbti">MBTI</span>
-        <span class="tag" id="profileSmoking">흡연</span>
-        <span class="tag" id="profileDrinking">음주</span>
-        <span class="tag" id="profileSleepTime">수면 시간</span>
+      <!-- 오른쪽: 프로필 수정 버튼 -->
+      <div class="profile-summary-actions">
+        <button type="button"
+                class="btn btn-dark"
+                onclick="location.href='${contextPath}/members/mypage/edit'">
+          프로필 수정
+        </button>
+      </div>
+    </div>
+
+    <!-- ✅ 하단: 태그 + 취미/선호/반려동물 (네가 준 내용 그대로 포함) -->
+    <div class="profile-summary-bottom">
+
+      <!-- 첫 줄: 라이프스타일 태그 -->
+      <div class="profile-tags-row">
+        <span class="tag-pill" id="profileWorkType">직업/라이프스타일</span>
+        <span class="tag-pill" id="profileMbti">MBTI</span>
+        <span class="tag-pill" id="profileSmoking">흡연</span>
+        <span class="tag-pill" id="profileDrinking">음주</span>
+        <span class="tag-pill" id="profileSleepTime">수면 시간</span>
       </div>
 
-      <div class="profile-subsection">
-        <h3>취미</h3>
-        <div id="profileHobbies" class="chip-list"></div>
-      </div>
+      <!-- 둘째 줄: 취미 / 생활선호 / 반려동물 -->
+      <div class="profile-detail-row">
 
-      <div class="profile-subsection">
-        <h3>생활 선호</h3>
-        <div id="profilePreferences" class="chip-list"></div>
-      </div>
+        <div class="profile-subsection">
+          <h3>취미</h3>
+          <div id="profileHobbies" class="chip-list"></div>
+        </div>
 
-      <div class="profile-subsection">
-        <h3>반려동물</h3>
-        <div id="profilePets" class="chip-list"></div>
+        <div class="profile-subsection">
+          <h3>생활 선호</h3>
+          <div id="profilePreferences" class="chip-list"></div>
+        </div>
+
+        <div class="profile-subsection">
+          <h3>반려동물</h3>
+          <div id="profilePets" class="chip-list"></div>
+        </div>
+
       </div>
     </div>
   </section>
 
-  <!-- 오른쪽: 내 정보 수정 폼 -->
-  <section class="mypage-right">
-    <h2>내 프로필 수정</h2>
+  <!-- ✅ 아래쪽: 탭 영역 (관심 목록 / 내 게시글 / 활동 내역 / 계정 설정 등) -->
+  <nav class="mypage-tabs">
+    <button class="mypage-tab active" data-tab="favorites">관심 목록</button>
+    <button class="mypage-tab" data-tab="posts">내 게시글</button>
+    <button class="mypage-tab" data-tab="activities">활동 내역</button>
+    <button class="mypage-tab" data-tab="account">계정 설정</button>
+  </nav>
 
-    <form id="mypageForm">
-      <div class="form-row">
-        <label for="mpName">이름</label>
-        <input type="text" id="mpName" maxlength="50">
-      </div>
-
-      <div class="form-row">
-        <label for="mpPhone">전화번호</label>
-        <input type="text" id="mpPhone" placeholder="010-1234-5678">
-      </div>
-
-      <div class="form-row">
-        <label for="mpWorkType">직업/라이프스타일</label>
-        <select id="mpWorkType">
-          <option value="">선택해주세요</option>
-          <!-- /api/members/form-codes로 채움 -->
-        </select>
-      </div>
-
-      <div class="form-row">
-        <label for="mpSleepTime">취침 시간</label>
-        <select id="mpSleepTime">
-          <option value="">선택 안 함</option>
-          <option value="EARLY">일찍 잠 (22시 이전)</option>
-          <option value="NORMAL">보통 (22~24시)</option>
-          <option value="LATE">늦게 잠 (자정 이후)</option>
-        </select>
-      </div>
-
-      <div class="form-row">
-        <label for="mpSmoking">흡연 여부</label>
-        <select id="mpSmoking">
-          <option value="NON_SMOKER">비흡연</option>
-          <option value="SMOKER">흡연</option>
-        </select>
-      </div>
-
-      <div class="form-row">
-        <label for="mpDrinking">음주 빈도</label>
-        <select id="mpDrinking">
-          <option value="NONE">안 마심</option>
-          <option value="SOCIAL">가끔</option>
-          <option value="OFTEN">자주</option>
-        </select>
-      </div>
-
-      <div class="form-row">
-        <label for="mpMbti">MBTI</label>
-        <select id="mpMbti">
-            <option value="">선택 안함</option>
-            <option value="INTJ">INTJ</option>
-            <option value="INTP">INTP</option>
-            <option value="INFJ">INFJ</option>
-            <option value="INFP">INFP</option>
-            <option value="ISTJ">ISTJ</option>
-            <option value="ISTP">ISTP</option>
-            <option value="ISFJ">ISFJ</option>
-            <option value="ISFP">ISFP</option>
-            <option value="ENTJ">ENTJ</option>
-            <option value="ENTP">ENTP</option>
-            <option value="ENFJ">ENFJ</option>
-            <option value="ENFP">ENFP</option>
-            <option value="ESTJ">ESTJ</option>
-            <option value="ESTP">ESTP</option>
-            <option value="ESFJ">ESFJ</option>
-            <option value="ESFP">ESFP</option>
-        </select>
-      </div>
-
-      <div class="form-row">
-        <label>취미</label>
-        <div id="mpHobbyCheckboxList" class="checkbox-group">
-          <!-- form-codes로 렌더링 -->
-        </div>
-      </div>
-
-      <div class="form-row">
-        <label>생활 선호</label>
-        <div id="mpPreferenceCheckboxList" class="checkbox-group">
-          <!-- form-codes로 렌더링 -->
-        </div>
-      </div>
-
-      <div class="form-row">
-        <label>반려동물</label>
-        <div id="mpPetCheckboxList" class="checkbox-group">
-          <!-- form-codes로 렌더링 -->
-        </div>
-      </div>
-
-      <div class="form-actions">
-        <span id="mypageError" class="form-error"></span>
-        <button type="submit" class="btn-primary">저장하기</button>
-      </div>
-    </form>
+  <section class="mypage-tab-content" id="tab-favorites">
+    <!-- TODO: 관심 목록 내용 -->
   </section>
-</div>
 
-<script type="module" src="${pageContext.request.contextPath}/resources/js/member/mypage.js"></script>
+  <section class="mypage-tab-content" id="tab-posts" style="display:none;">
+    <!-- TODO: 내 게시글 내용 -->
+  </section>
+
+  <section class="mypage-tab-content" id="tab-activities" style="display:none;">
+    <!-- TODO: 활동 내역 내용 -->
+  </section>
+
+  <!-- 🔐 계정 설정 탭 안에 비밀번호 변경 카드 + 모달 배치하면 됨 -->
+  <section class="mypage-tab-content" id="tab-account" style="display:none;">
+    <div class="mypage-section mypage-section--security">
+      <h3>비밀번호 변경</h3>
+      <p>비밀번호를 정기적으로 변경해 계정 보안을 강화하세요.</p>
+      <button type="button"
+              id="btnOpenPasswordModal"
+              class="btn btn-primary">
+        비밀번호 변경
+      </button>
+    </div>
+  </section>
+  <!-- 🔐 비밀번호 변경 모달 -->
+  <div id="passwordModalOverlay" class="password-modal-overlay" style="display:none;">
+    <div class="password-modal">
+      <h3>비밀번호 변경</h3>
+
+      <div class="password-modal-body">
+        <div class="form-group">
+          <label for="currentPassword">현재 비밀번호</label>
+          <input type="password" id="currentPassword" class="form-control">
+        </div>
+
+        <div class="form-group">
+          <label for="newPassword">새 비밀번호</label>
+          <input type="password" id="newPassword" class="form-control">
+        </div>
+
+        <div class="form-group">
+          <label for="confirmPassword">새 비밀번호 확인</label>
+          <input type="password" id="confirmPassword" class="form-control">
+        </div>
+
+        <p id="passwordChangeMessage" class="password-message"></p>
+      </div>
+
+      <div class="password-modal-footer">
+        <button type="button" id="btnCancelPasswordModal" class="btn btn-secondary">
+          취소
+        </button>
+        <button type="button" id="btnChangePassword" class="btn btn-primary">
+          비밀번호 변경
+        </button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script type="module" src="${pageContext.request.contextPath}/resources/js/member/mypageView.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/members/mypageEdit.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypageEdit.jsp
@@ -1,0 +1,158 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+  <title>마이페이지 - Roommate</title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/member/mypage-edit.css">
+</head>
+<body>
+
+<jsp:include page="/WEB-INF/views/common/header.jsp" />
+
+<div class="mypage-container">
+  <!-- 왼쪽: 프로필 카드 -->
+  <section class="mypage-left">
+    <div class="profile-card">
+      <div class="profile-photo-wrapper">
+        <img id="profilePhoto" src="" alt="프로필 사진" class="profile-photo">
+        <input type="file" id="photoFileInput" accept="image/*" style="display: none;"/>
+        <button type="button" class="btn-photo-upload" onclick="document.getElementById('photoFileInput').click();">
+        사진 변경
+        </button>
+      </div>
+      <div class="profile-main-info">
+        <h2 id="profileName">이름</h2>
+        <p id="profileEmail" class="profile-email">email@example.com</p>
+        <p id="profilePhone" class="profile-phone">010-0000-0000</p>
+      </div>
+
+      <div class="profile-tags">
+        <span class="tag" id="profileWorkType">직업/라이프스타일</span>
+        <span class="tag" id="profileMbti">MBTI</span>
+        <span class="tag" id="profileSmoking">흡연</span>
+        <span class="tag" id="profileDrinking">음주</span>
+        <span class="tag" id="profileSleepTime">수면 시간</span>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>취미</h3>
+        <div id="profileHobbies" class="chip-list"></div>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>생활 선호</h3>
+        <div id="profilePreferences" class="chip-list"></div>
+      </div>
+
+      <div class="profile-subsection">
+        <h3>반려동물</h3>
+        <div id="profilePets" class="chip-list"></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 오른쪽: 내 정보 수정 폼 -->
+  <section class="mypage-right">
+    <h2>내 프로필 수정</h2>
+
+    <form id="mypageForm">
+      <div class="form-row">
+        <label for="mpName">이름</label>
+        <input type="text" id="mpName" maxlength="50">
+      </div>
+
+      <div class="form-row">
+        <label for="mpPhone">전화번호</label>
+        <input type="text" id="mpPhone" placeholder="010-1234-5678">
+      </div>
+
+      <div class="form-row">
+        <label for="mpWorkType">직업/라이프스타일</label>
+        <select id="mpWorkType">
+          <option value="">선택해주세요</option>
+          <!-- /api/members/form-codes로 채움 -->
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpSleepTime">취침 시간</label>
+        <select id="mpSleepTime">
+          <option value="">선택 안 함</option>
+          <option value="EARLY">일찍 잠 (22시 이전)</option>
+          <option value="NORMAL">보통 (22~24시)</option>
+          <option value="LATE">늦게 잠 (자정 이후)</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpSmoking">흡연 여부</label>
+        <select id="mpSmoking">
+          <option value="NON_SMOKER">비흡연</option>
+          <option value="SMOKER">흡연</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpDrinking">음주 빈도</label>
+        <select id="mpDrinking">
+          <option value="NONE">안 마심</option>
+          <option value="SOCIAL">가끔</option>
+          <option value="OFTEN">자주</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label for="mpMbti">MBTI</label>
+        <select id="mpMbti">
+            <option value="">선택 안함</option>
+            <option value="INTJ">INTJ</option>
+            <option value="INTP">INTP</option>
+            <option value="INFJ">INFJ</option>
+            <option value="INFP">INFP</option>
+            <option value="ISTJ">ISTJ</option>
+            <option value="ISTP">ISTP</option>
+            <option value="ISFJ">ISFJ</option>
+            <option value="ISFP">ISFP</option>
+            <option value="ENTJ">ENTJ</option>
+            <option value="ENTP">ENTP</option>
+            <option value="ENFJ">ENFJ</option>
+            <option value="ENFP">ENFP</option>
+            <option value="ESTJ">ESTJ</option>
+            <option value="ESTP">ESTP</option>
+            <option value="ESFJ">ESFJ</option>
+            <option value="ESFP">ESFP</option>
+        </select>
+      </div>
+
+      <div class="form-row">
+        <label>취미</label>
+        <div id="mpHobbyCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-row">
+        <label>생활 선호</label>
+        <div id="mpPreferenceCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-row">
+        <label>반려동물</label>
+        <div id="mpPetCheckboxList" class="checkbox-group">
+          <!-- form-codes로 렌더링 -->
+        </div>
+      </div>
+
+      <div class="form-actions">
+        <span id="mypageError" class="form-error"></span>
+        <button type="submit" class="btn-primary">저장하기</button>
+      </div>
+    </form>
+  </section>
+</div>
+
+<script type="module" src="${pageContext.request.contextPath}/resources/js/member/mypageEdit.js"></script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
+</body>
+</html>

--- a/src/main/webapp/resources/css/member/mypage-edit.css
+++ b/src/main/webapp/resources/css/member/mypage-edit.css
@@ -1,3 +1,4 @@
+/* /resources/css/member/mypage-edit.css */
 /* ===== 공통 ===== */
 * {
   box-sizing: border-box;

--- a/src/main/webapp/resources/css/member/mypage-view.css
+++ b/src/main/webapp/resources/css/member/mypage-view.css
@@ -1,0 +1,363 @@
+/* /resources/css/member/mypage-view.css */
+/* ===== 공통 레이아웃 ===== */
+
+.mypage-main {
+  max-width: 1100px;
+  margin: 40px auto;
+  padding: 0 16px;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+/* ===== 프로필 요약 카드 ===== */
+
+.profile-summary-card {
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  padding: 24px 28px;
+  margin-bottom: 24px;
+}
+
+/* 위쪽: 사진 + 기본 정보 + 버튼 */
+.profile-summary-top {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+/* 프로필 사진 */
+.profile-summary-photo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-photo-lg {
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #e5e7eb;
+}
+
+/* 사진 변경 버튼 */
+.btn-photo-upload {
+  margin-top: 4px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  cursor: pointer;
+}
+
+.btn-photo-upload:hover {
+  background: #eef2ff;
+  border-color: #4f46e5;
+}
+
+/* 가운데 정보 영역 */
+.profile-summary-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-label {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  margin: 0 0 4px;
+}
+
+.profile-name {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+/* 이메일/전화/가입일 */
+.profile-contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.profile-contact-item::before {
+  content: "• ";
+}
+
+/* 오른쪽: 프로필 수정 버튼 */
+.profile-summary-actions {
+  display: flex;
+  align-items: flex-start;
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-dark {
+  background: #111827;
+  color: #ffffff;
+}
+
+.btn-dark:hover {
+  background: #000000;
+}
+
+/* 아래쪽: 태그 & 상세 정보 */
+.profile-summary-bottom {
+  margin-top: 18px;
+  border-top: 1px solid #f3f4f6;
+  padding-top: 16px;
+}
+
+/* 태그(라이프스타일) */
+.profile-tags-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tag-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #f3f4ff;
+  color: #4f46e5;
+  font-size: 0.8rem;
+}
+
+/* 취미/생활선호/반려동물 블록 */
+.profile-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.profile-subsection {
+  flex: 1;
+  min-width: 180px;
+}
+
+.profile-subsection h3 {
+  font-size: 0.95rem;
+  margin: 0 0 8px;
+}
+
+/* chip 리스트 */
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip-list .chip {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #f3f4f6;
+  font-size: 0.8rem;
+}
+
+.chip-empty {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+/* ===== 탭 영역 ===== */
+
+.mypage-tabs {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.mypage-tab {
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  cursor: pointer;
+}
+
+.mypage-tab.active {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+}
+
+.mypage-tab-content {
+  margin-top: 16px;
+}
+
+/* ===== 계정 설정 섹션 (비밀번호 변경 카드 등) ===== */
+
+.mypage-section {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px 22px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.04);
+}
+
+.mypage-section--security h3 {
+  margin: 0 0 6px;
+}
+
+.mypage-section--security p {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+/* ===== 비밀번호 변경 모달 ===== */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: none;            /* 기본 숨김 */
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.modal {
+  width: 420px;
+  max-width: 90%;
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+  padding: 20px 22px 18px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.modal-close-btn {
+  border: none;
+  background: transparent;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.modal-body .form-group {
+  margin-bottom: 12px;
+}
+
+.modal-body label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 0.9rem;
+}
+
+.modal-body input[type="password"] {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 0.9rem;
+}
+
+.modal-body input[type="password"]:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 1px #4f46e5;
+}
+
+.modal-body .form-text {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.modal-footer {
+  margin-top: 10px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* 재사용 버튼 스타일 */
+.btn-primary {
+  background: #4f46e5;
+  color: #ffffff;
+}
+
+.btn-primary:hover {
+  background: #4338ca;
+}
+
+.btn-secondary {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.btn-secondary:hover {
+  background: #d1d5db;
+}
+
+.mypage-security__message {
+  margin-top: 4px;
+  font-size: 0.8rem;
+}
+
+.password-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;           /* JS에서 flex로 바꿈 */
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.4);
+  z-index: 1000;
+}
+
+.password-modal {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px 28px;
+  width: 360px;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.15);
+}
+
+.password-modal .form-group {
+  margin-bottom: 12px;
+}
+
+.password-modal .form-control {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+}
+
+.password-modal-footer {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.password-message {
+  min-height: 18px;
+  font-size: 13px;
+  margin-top: 4px;
+}

--- a/src/main/webapp/resources/js/member/mypageEdit.js
+++ b/src/main/webapp/resources/js/member/mypageEdit.js
@@ -1,4 +1,4 @@
-// /resources/js/member/mypage.js
+// /resources/js/member/mypageEdit.js
 
 import { apiRequest } from "../common/apiClient.js";
 import { requireLogin } from "../common/authGuard.js";

--- a/src/main/webapp/resources/js/member/mypageView.js
+++ b/src/main/webapp/resources/js/member/mypageView.js
@@ -1,0 +1,340 @@
+// /resources/js/member/mypageView.js
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const ok = requireLogin();
+  if (!ok) return;
+
+  initTabs();
+  setupPhotoUpload();
+  setupPasswordModal();
+  setupPasswordChange();
+
+  try {
+    await loadMyProfile();
+  } catch (e) {
+    console.error("mypage view init error:", e);
+  }
+});
+
+/**
+ * 내 프로필 카드 데이터 채우기
+ */
+async function loadMyProfile() {
+  const res = await apiRequest("/api/members/me", { method: "GET" });
+  if (!res.ok) {
+    throw new Error("failed to load /api/members/me");
+  }
+
+  const data = await res.json();
+
+  const profileName = document.getElementById("profileName");
+  const profileEmail = document.getElementById("profileEmail");
+  const profilePhone = document.getElementById("profilePhone");
+  const profilePhoto = document.getElementById("profilePhoto");
+  const profileWorkType = document.getElementById("profileWorkType");
+  const profileMbti = document.getElementById("profileMbti");
+  const profileSmoking = document.getElementById("profileSmoking");
+  const profileDrinking = document.getElementById("profileDrinking");
+  const profileSleepTime = document.getElementById("profileSleepTime");
+  const profileHobbies = document.getElementById("profileHobbies");
+  const profilePreferences = document.getElementById("profilePreferences");
+  const profilePets = document.getElementById("profilePets");
+  const profileJoinedAt = document.getElementById("profileJoinedAt");
+
+  profileName && (profileName.textContent = data.name || "");
+  profileEmail && (profileEmail.textContent = data.email || "");
+  profilePhone && (profilePhone.textContent = data.phone || "");
+
+  if (profilePhoto) {
+    const url = data.photo_url || data.photoUrl || "";
+    profilePhoto.src = url || "/resources/img/default-profile.png";
+  }
+
+  if (profileWorkType) {
+    profileWorkType.textContent = data.work_type_name || "직업/라이프스타일 미설정";
+  }
+
+  if (profileMbti) {
+    profileMbti.textContent = data.mbti || "MBTI 미설정";
+  }
+
+  if (profileSmoking) {
+    profileSmoking.textContent = data.smoking === "SMOKER" ? "흡연" : "비흡연";
+  }
+
+  if (profileDrinking) {
+    let drinkLabel = "음주 미설정";
+    if (data.drinking === "NONE") drinkLabel = "음주 안함";
+    if (data.drinking === "SOCIAL") drinkLabel = "가끔 마심";
+    if (data.drinking === "OFTEN") drinkLabel = "자주 마심";
+    profileDrinking.textContent = drinkLabel;
+  }
+
+  if (profileSleepTime) {
+    const raw = data.sleep_time || data.sleepTime;
+    let label = "수면 시간 미설정";
+
+    if (raw === "EARLY") label = "일찍 잠 (22시 이전)";
+    if (raw === "NORMAL") label = "보통 (22~24시)";
+    if (raw === "LATE") label = "늦게 잠 (자정 이후)";
+
+    profileSleepTime.textContent = label;
+  }
+
+  if (profileJoinedAt) {
+    const createdRaw = data.member_created_at || data.memberCreatedAt;
+    if (createdRaw) {
+      const date = new Date(createdRaw);
+      const text = `${date.getFullYear()}. ${date.getMonth() + 1}. ${date.getDate()}.`;
+      profileJoinedAt.textContent = `가입일: ${text}`;
+    } else {
+      profileJoinedAt.textContent = "";
+    }
+  }
+
+  // chip 리스트 렌더링
+  renderChips(profileHobbies, data.hobbies || [], "hobby_name");
+  renderChips(profilePreferences, data.preferences || [], "preference_name");
+  renderChips(profilePets, data.pets || [], "pet_name");
+}
+
+function renderChips(container, items, labelKey) {
+  if (!container) return;
+  container.innerHTML = "";
+
+  if (!Array.isArray(items) || items.length === 0) {
+    const span = document.createElement("span");
+    span.classList.add("chip-empty");
+    span.textContent = "없음";
+    container.appendChild(span);
+    return;
+  }
+
+  items.forEach((item) => {
+    const chip = document.createElement("span");
+    chip.classList.add("chip");
+    chip.textContent = item[labelKey];
+    container.appendChild(chip);
+  });
+}
+
+/**
+ * 프로필 사진 업로드
+ * -> PUT /api/members/me/photo (FormData)
+ */
+function setupPhotoUpload() {
+  const input = document.getElementById("photoFileInput");
+  const profilePhoto = document.getElementById("profilePhoto");
+
+  if (!input) return;
+
+  input.addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await apiRequest("/api/members/me/photo", {
+        method: "PUT",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        alert("프로필 사진 업로드에 실패했습니다.");
+        return;
+      }
+
+      const data = await res.json();
+      const url = data.photo_url || data.photoUrl;
+
+      if (profilePhoto && url) {
+        profilePhoto.src = url;
+      }
+
+      alert("프로필 사진이 변경되었습니다.");
+    } catch (err) {
+      console.error("photo upload error:", err);
+      alert("서버 오류가 발생했습니다.");
+    } finally {
+      input.value = "";
+    }
+  });
+}
+
+/**
+ * 탭 전환 (관심 목록 / 내 게시글 / 활동 내역 / 계정 설정)
+ */
+function initTabs() {
+  const tabs = document.querySelectorAll(".mypage-tab");
+  const contents = {
+    favorites: document.getElementById("tab-favorites"),
+    posts: document.getElementById("tab-posts"),
+    activities: document.getElementById("tab-activities"),
+    account: document.getElementById("tab-account"),
+  };
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const key = tab.dataset.tab;
+      // active 클래스 변경
+      tabs.forEach((t) => t.classList.remove("active"));
+      tab.classList.add("active");
+
+      // 컨텐츠 토글
+      Object.entries(contents).forEach(([k, el]) => {
+        if (!el) return;
+        el.style.display = k === key ? "block" : "none";
+      });
+    });
+  });
+}
+
+/**
+ * 비밀번호 변경 모달 열기/닫기
+ */
+function setupPasswordModal() {
+  const openBtn = document.getElementById("btnOpenPasswordModal");
+  const overlay = document.getElementById("passwordModalOverlay");
+  const cancelBtn = document.getElementById("btnCancelPasswordModal");
+
+  if (!openBtn || !overlay) return;
+
+  const open = () => {
+    // 폼 초기화
+    ["currentPassword", "newPassword", "confirmPassword"].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.value = "";
+    });
+    const msgEl = document.getElementById("passwordChangeMessage");
+    if (msgEl) {
+      msgEl.textContent = "";
+      msgEl.style.color = "";
+    }
+
+    overlay.style.display = "flex";
+  };
+
+  const close = () => {
+    overlay.style.display = "none";
+  };
+
+  openBtn.addEventListener("click", open);
+  cancelBtn && cancelBtn.addEventListener("click", close);
+
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) {
+      close();
+    }
+  });
+}
+
+/**
+ * 비밀번호 변경 요청
+ * -> PUT /api/members/me/password
+ */
+function setupPasswordChange() {
+  const btn = document.getElementById("btnChangePassword");
+  if (!btn) return;
+
+  btn.addEventListener("click", handlePasswordChange);
+}
+
+async function handlePasswordChange() {
+  const currentPasswordEl = document.getElementById("currentPassword");
+  const newPasswordEl = document.getElementById("newPassword");
+  const confirmPasswordEl = document.getElementById("confirmPassword");
+  const messageEl = document.getElementById("passwordChangeMessage");
+  const overlay = document.getElementById("passwordModalOverlay");
+
+  const currentPassword = currentPasswordEl?.value.trim() ?? "";
+  const newPassword = newPasswordEl?.value.trim() ?? "";
+  const confirmPassword = confirmPasswordEl?.value.trim() ?? "";
+
+  if (messageEl) {
+    messageEl.textContent = "";
+    messageEl.style.color = "";
+  }
+
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    alert("모든 비밀번호 항목을 입력해 주세요.");
+    return;
+  }
+
+  if (newPassword.length < 8) {
+    alert("새 비밀번호는 8자 이상이어야 합니다.");
+    return;
+  }
+
+  if (newPassword !== confirmPassword) {
+    alert("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
+    return;
+  }
+
+  const payload = {
+    current_password: currentPassword,
+    new_password: newPassword,
+    confirm_password: confirmPassword,
+  };
+
+  try {
+    const res = await apiRequest("/api/members/me/password", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      let msg = "비밀번호 변경에 실패했습니다.";
+      try {
+        const errBody = await res.json();
+        if (errBody?.code === "INVALID_CURRENT_PASSWORD") {
+          msg = "현재 비밀번호가 올바르지 않습니다.";
+        } else if (errBody?.code === "PASSWORD_CONFIRM_MISMATCH") {
+          msg = "새 비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+        } else if (errBody?.code === "PASSWORD_SAME_AS_OLD") {
+          msg = "기존 비밀번호와 동일한 비밀번호입니다.";
+        } else if (errBody?.message) {
+          msg = errBody.message;
+        }
+      } catch (_) {}
+
+      if (messageEl) {
+        messageEl.textContent = msg;
+        messageEl.style.color = "red";
+      } else {
+        alert(msg);
+      }
+      return;
+    }
+
+    const data = await res.json();
+    const msg = data?.message || "비밀번호가 변경되었습니다.";
+
+    if (messageEl) {
+      messageEl.textContent = msg;
+      messageEl.style.color = "green";
+    } else {
+      alert(msg);
+    }
+
+    // 잠깐 보여주고 모달 닫기 (로그아웃 정책은 필요시 추가)
+    setTimeout(() => {
+      if (overlay) overlay.style.display = "none";
+       window.location.href = "/";
+    }, 1000);
+  } catch (err) {
+    console.error("password change error:", err);
+    if (messageEl) {
+      messageEl.textContent = "서버 오류가 발생했습니다.";
+      messageEl.style.color = "red";
+    } else {
+      alert("서버 오류가 발생했습니다.");
+    }
+  }
+}


### PR DESCRIPTION
##  작업 개요

마이페이지에서 회원의 **비밀번호를 안전하게 변경할 수 있는 계정 보안 기능**을 추가하고,  
기존 마이페이지 화면을 **보기 페이지 / 수정 페이지로 분리**하여 UX를 개선했습니다.

비밀번호 변경 시에는 **현재 비밀번호 검증 + BCrypt 암호화 저장 + Refresh Token 무효화**까지 포함하여
실무 수준의 보안 정책을 적용했습니다.

---

##  주요 구현 내용

### 1. 비밀번호 변경 API 추가
- `PUT /api/members/me/password`
- 현재 비밀번호 검증
- 새 비밀번호 BCrypt 암호화 저장
- 기존 Refresh Token 삭제 → 강제 로그아웃 처리
- 전용 DTO 분리
  - `MemberPasswordChangeRequest`
  - `PasswordChangeResponse`

### 2. 에러 코드 확장
- `INVALID_CURRENT_PASSWORD`
- `PASSWORD_CONFIRM_MISMATCH`
- `PASSWORD_SAME_AS_OLD`

### 3. 마이페이지 화면 구조 개선
- 기존 화면 → **보기 페이지(mypage.jsp)**
- 수정 전용 페이지 → **mypageEdit.jsp**
- CSS/JS 파일도 View / Edit 기준으로 분리
  - `mypage-view.css / mypage-edit.css`
  - `mypageView.js / mypageEdit.js`

### 4. 프론트엔드 기능
- 비밀번호 변경 Ajax 연동
- 프론트 유효성 검사(길이, 일치 여부)
- 성공/실패 메시지 처리
- 성공 시 강제 로그아웃 및 메인 페이지 이동

---

##  테스트 내용

-  현재 비밀번호 틀린 경우 에러 처리 확인
-  기존 비밀번호와 동일한 비밀번호 입력 시 차단 확인
-  새 비밀번호 / 확인 불일치 시 차단 확인
-  정상 변경 시:
  - DB 비밀번호 변경 확인
  - Refresh Token 삭제 확인
  - 강제 로그아웃 후 재로그인 정상 동작 확인
-  마이페이지 보기/수정 화면 정상 분리 및 렌더링 확인

---

##  변경 파일 요약

### Backend
- `MemberRestController`
- `MemberService / MemberServiceImpl`
- `MemberRepository`
- `Member.xml`
- `ErrorCode`
- `MemberPasswordChangeRequest`
- `PasswordChangeResponse`

### Frontend
- `mypage.jsp`
- `mypageEdit.jsp`
- `mypageView.js`
- `mypageEdit.js`
- `mypage-view.css`
- `mypage-edit.css`

---
