### PR TITLE
feat: 관심목록(찜) 기능 전체 구현 및 마이페이지/지도/상세 연동

### DIFF
--- a/src/main/java/com/roommate/common/security/SecurityConfig.java
+++ b/src/main/java/com/roommate/common/security/SecurityConfig.java
@@ -68,8 +68,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
                 // 2) 룸 조회용 API (지도/요약/상세 데이터) - 모두 허용
                 .antMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
+                // 3) 찜 조회용 API- 허용
+                .antMatchers(HttpMethod.GET, "/api/favorites/**").permitAll()
 
-                // 3) 인증/회원가입/폼코드 등 공개 API
+                // 4) 인증/회원가입/폼코드 등 공개 API
                 .antMatchers(
                         "/api/auth/signup",
                         "/api/auth/login",
@@ -77,25 +79,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/api/members/form-codes",
                         "/api/files/**").permitAll()
 
-                // 4) 테스트/로그인 관련 뷰 페이지 - 공개
+                // 5) 테스트/로그인 관련 뷰 페이지 - 공개
                 .antMatchers("/auth/login-test", "/auth/me-test", "/auth/login").permitAll()
 
-                // 5) 메인/지도/정적 리소스 - 공개
+                // 6) 메인/지도/정적 리소스 - 공개
                 .antMatchers("/", "/room/map", "/index", "/resources/**").permitAll()
 
                 .antMatchers(HttpMethod.POST, "/api/members/**").authenticated()
                 .antMatchers(HttpMethod.PUT, "/api/members/**").authenticated()
                 .antMatchers(HttpMethod.DELETE, "/api/members/**").authenticated()
 
-                // 6) 방 작성/수정/삭제 API - 로그인 필요
+                // 7) 방 작성/수정/삭제 API - 로그인 필요
                 .antMatchers(HttpMethod.POST, "/api/rooms/**").authenticated()
                 .antMatchers(HttpMethod.PUT, "/api/rooms/**").authenticated()
                 .antMatchers(HttpMethod.DELETE, "/api/rooms/**").authenticated()
 
-                // 7) 관리자 API
+                // 8) 찜 추가/수정/삭제 API - 로그인 필요
+                .antMatchers(HttpMethod.POST, "/api/favorites/**").authenticated()
+                .antMatchers(HttpMethod.DELETE, "/api/favorites/**").authenticated()
+
+                // 9) 관리자 API
                 .antMatchers("/api/admin/**").hasRole("ADMIN")
 
-                // 8) 그 외 나머지 요청은 전부 인증 필요
+                // 10) 그 외 나머지 요청은 전부 인증 필요
                 .anyRequest().authenticated();
         http.formLogin().disable().httpBasic().disable();
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/roommate/domain/favorite/controller/FavoriteRestController.java
+++ b/src/main/java/com/roommate/domain/favorite/controller/FavoriteRestController.java
@@ -1,4 +1,37 @@
 package com.roommate.domain.favorite.controller;
 
+import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.favorite.dto.response.FavoriteRoomResponse;
+import com.roommate.domain.favorite.service.FavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/favorites")
+@RequiredArgsConstructor
 public class FavoriteRestController {
+
+    private final FavoriteService favoriteService;
+
+    @GetMapping("/me")
+    public ResponseEntity<List<FavoriteRoomResponse>> getMyFavorites(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<FavoriteRoomResponse> favoriteRoomResponses = favoriteService.getMyFavoriteRooms(userDetails.getMemberId());
+        return ResponseEntity.ok(favoriteRoomResponses);
+    }
+
+    @PostMapping("/{roomId}")
+    public ResponseEntity<Void> addFavorite(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId) {
+        favoriteService.addFavorite(userDetails.getMemberId(), roomId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<Void> removeFavorite(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long roomId) {
+        favoriteService.removeFavorite(userDetails.getMemberId(), roomId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/roommate/domain/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/com/roommate/domain/favorite/dto/FavoriteRequest.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.favorite.dto;
-
-public class FavoriteRequest {
-}

--- a/src/main/java/com/roommate/domain/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/com/roommate/domain/favorite/dto/FavoriteResponse.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.favorite.dto;
-
-public class FavoriteResponse {
-}

--- a/src/main/java/com/roommate/domain/favorite/dto/request/FavoriteRequest.java
+++ b/src/main/java/com/roommate/domain/favorite/dto/request/FavoriteRequest.java
@@ -1,0 +1,14 @@
+package com.roommate.domain.favorite.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FavoriteRequest {
+    private Long roomId;
+}

--- a/src/main/java/com/roommate/domain/favorite/dto/response/FavoriteRoomResponse.java
+++ b/src/main/java/com/roommate/domain/favorite/dto/response/FavoriteRoomResponse.java
@@ -1,0 +1,19 @@
+package com.roommate.domain.favorite.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.roommate.domain.room.entity.RoomStatusEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class FavoriteRoomResponse {
+    private final Long roomId;
+    private final String roomTitle;
+    private final Double deposit;
+    private final Double monthlyRent;
+    private final RoomStatusEnum status;
+    private final String thumbnailUrl;
+}

--- a/src/main/java/com/roommate/domain/favorite/entity/FavoriteEntity.java
+++ b/src/main/java/com/roommate/domain/favorite/entity/FavoriteEntity.java
@@ -1,4 +1,18 @@
 package com.roommate.domain.favorite.entity;
 
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
 public class FavoriteEntity {
+    private Long favoriteId;
+    private Long roomId;
+    private Long memberId;
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/src/main/java/com/roommate/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/roommate/domain/favorite/repository/FavoriteRepository.java
@@ -1,9 +1,20 @@
 package com.roommate.domain.favorite.repository;
 
+import com.roommate.domain.favorite.dto.response.FavoriteRoomResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface FavoriteRepository {
     void deleteByMemberId(@Param("memberId") Long memberId);
+
+    List<FavoriteRoomResponse> findMyFavoriteRooms(@Param("memberId") Long memberId);
+
+    int existsByMemberIdAndRoomId(@Param("memberId") Long memberId, @Param("roomId") Long roomId);
+
+    void save(@Param("memberId") Long memberId, @Param("roomId") Long roomId);
+
+    void deleteByMemberIdAndRoomId(@Param("memberId") Long memberId, @Param("roomId") Long roomId);
 }

--- a/src/main/java/com/roommate/domain/favorite/service/FavoriteSerivce.java
+++ b/src/main/java/com/roommate/domain/favorite/service/FavoriteSerivce.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.favorite.service;
-
-public interface FavoriteSerivce {
-}

--- a/src/main/java/com/roommate/domain/favorite/service/FavoriteSerivceImp.java
+++ b/src/main/java/com/roommate/domain/favorite/service/FavoriteSerivceImp.java
@@ -1,4 +1,0 @@
-package com.roommate.domain.favorite.service;
-
-public class FavoriteSerivceImp implements FavoriteSerivce{
-}

--- a/src/main/java/com/roommate/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/roommate/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,13 @@
+package com.roommate.domain.favorite.service;
+
+import com.roommate.domain.favorite.dto.response.FavoriteRoomResponse;
+
+import java.util.List;
+
+public interface FavoriteService {
+    public List<FavoriteRoomResponse> getMyFavoriteRooms(Long memberId);
+
+    public void addFavorite(Long memberId, Long roomId);
+
+    public void removeFavorite(Long memberId, Long roomId);
+}

--- a/src/main/java/com/roommate/domain/favorite/service/FavoriteServiceImp.java
+++ b/src/main/java/com/roommate/domain/favorite/service/FavoriteServiceImp.java
@@ -1,0 +1,44 @@
+package com.roommate.domain.favorite.service;
+
+import com.roommate.common.exception.ApiException;
+import com.roommate.common.exception.ErrorCode;
+import com.roommate.domain.favorite.dto.response.FavoriteRoomResponse;
+import com.roommate.domain.favorite.repository.FavoriteRepository;
+import com.roommate.domain.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteServiceImp implements FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final RoomRepository roomRepository;
+
+    @Override
+    @Transactional
+    public List<FavoriteRoomResponse> getMyFavoriteRooms(Long memberId) {
+        return favoriteRepository.findMyFavoriteRooms(memberId);
+    }
+
+    @Override
+    public void addFavorite(Long memberId, Long roomId) {
+        if (roomRepository.findById(roomId) == null) {
+            throw new ApiException(ErrorCode.ROOM_NOT_FOUND);
+        }
+        int exists = favoriteRepository.existsByMemberIdAndRoomId(memberId, roomId);
+        if (exists > 0) {
+            throw new ApiException(ErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+        favoriteRepository.save(memberId, roomId);
+    }
+
+    @Override
+    @Transactional
+    public void removeFavorite(Long memberId, Long roomId) {
+        favoriteRepository.deleteByMemberIdAndRoomId(memberId, roomId);
+    }
+}

--- a/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
@@ -44,6 +44,9 @@ public class RoomDetailResponse {
     // 이미지 리스트
     private final List<String> imageUrls;
 
+    //찜하기
+    boolean favorited;
+    
     //  Kakao 딥링크 (DB에 저장 X, 응답 시 계산)
     private final String kakaoMapUrl;
     private final String kakaoDirectionUrl;

--- a/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
@@ -2,6 +2,7 @@ package com.roommate.domain.room.service;
 
 import com.roommate.common.exception.ApiException;
 import com.roommate.common.exception.ErrorCode;
+import com.roommate.domain.favorite.repository.FavoriteRepository;
 import com.roommate.domain.room.dto.request.RoomCreateRequest;
 import com.roommate.domain.room.dto.request.RoomStatusUpdateRequest;
 import com.roommate.domain.room.dto.request.RoomUpdateRequest;
@@ -35,6 +36,7 @@ public class RoomServiceImpl implements RoomService {
     private final RoomRepository roomRepository;
     private final RoomImageRepository roomImageRepository;
     private final KakaoMapService kakaoMapService;
+    private final FavoriteRepository favoriteRepository;
 
     /**
      * 방 이미지 전체 교체
@@ -260,6 +262,12 @@ public class RoomServiceImpl implements RoomService {
             kakaoRoadviewUrl = KAKAO_MAP_BASE + "/roadview/" + lat + "," + lng;
         }
 
+        boolean favorited = false;
+        if (currentMemberId != null) {
+            int exists = favoriteRepository.existsByMemberIdAndRoomId(currentMemberId, roomId);
+            favorited = (exists > 0);
+        }
+
         return new RoomDetailResponse(
                 roomDetailEntity.getRoomId(),
                 roomDetailEntity.getTitle(),
@@ -285,6 +293,7 @@ public class RoomServiceImpl implements RoomService {
                 roomDetailEntity.getOwnerNickname(),
                 roomDetailEntity.getOwnerPhotoUrl(),
                 imageUrls,
+                favorited,
                 kakaoMapUrl,
                 kakaoDirectionUrl,
                 kakaoRoadviewUrl

--- a/src/main/resources/mapper/favorite/Favorite.xml
+++ b/src/main/resources/mapper/favorite/Favorite.xml
@@ -4,7 +4,42 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.roommate.domain.favorite.repository.FavoriteRepository">
-
+    <select id="findMyFavoriteRooms" parameterType="long" resultType="com.roommate.domain.favorite.dto.response.FavoriteRoomResponse">
+        SELECT
+        r.room_id           AS roomId,
+        r.room_title        AS roomTitle,
+        r.deposit           AS deposit,
+        r.monthly_rent      AS monthlyRent,
+        r.status            AS status,
+        (
+        SELECT ri.image_url
+        FROM room_image ri
+        WHERE ri.room_id = r.room_id
+        ORDER BY ri.sort_order ASC, ri.image_id ASC
+        LIMIT 1
+        ) AS thumbnailUrl
+        FROM favorites f
+        INNER JOIN rooms r ON f.room_id = r.room_id
+        WHERE f.member_id = #{memberId}
+        AND r.deleted = 0
+        AND r.status NOT IN ('CLOSED', 'HIDDEN')
+        ORDER BY f.created_at DESC
+    </select>
+    <select id="existsByMemberIdAndRoomId" resultType="int">
+        SELECT COUNT(*)
+        FROM favorites
+        WHERE member_id = #{memberId}
+        AND room_id = #{roomId}
+    </select>
+    <insert id="save">
+        INSERT INTO favorites (member_id, room_id)
+        VALUES (#{memberId}, #{roomId})
+    </insert>
+    <delete id="deleteByMemberIdAndRoomId">
+        DELETE FROM favorites
+        WHERE member_id = #{memberId}
+        AND room_id = #{roomId}
+    </delete>
     <delete id="deleteByMemberId" parameterType="long">
         DELETE FROM favorites
         WHERE member_id = #{memberId}

--- a/src/main/webapp/WEB-INF/views/members/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypage.jsp
@@ -93,8 +93,16 @@
   </nav>
 
   <section class="mypage-tab-content" id="tab-favorites">
-    <!-- TODO: 관심 목록 내용 -->
-  </section>
+  <div class="mypage-section-header">
+    <h2 class="mypage-section-title">관심 방</h2>
+    <p class="mypage-section-subtitle">찜한 방들을 한눈에 볼 수 있어요.</p>
+  </div>
+
+  <div id="favoriteList" class="favorite-list">
+    <!-- JS에서 카드로 렌더링 -->
+    <p class="favorite-empty">아직 관심 등록한 방이 없습니다.</p>
+  </div>
+ </section>
 
   <section class="mypage-tab-content" id="tab-posts" style="display:none;">
     <!-- TODO: 내 게시글 내용 -->

--- a/src/main/webapp/WEB-INF/views/rooms/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/detail.jsp
@@ -25,10 +25,6 @@
         </button>
 
         <div class="room-detail-top-actions">
-            <!-- 공유 버튼은 나중에 JS로 연결 -->
-            <button type="button" class="icon-btn" title="공유하기">
-                🔗
-            </button>
             <!-- 신고 버튼도 나중에 JS 연결 -->
             <button type="button" class="icon-btn" title="신고하기">
                 🚩
@@ -154,9 +150,6 @@
                 <div class="room-author-extra">
                     <div class="room-author-stat">
                         👁 <span id="author-views">0</span> 회 열람
-                    </div>
-                    <div class="room-author-stat">
-                        ♡ <span id="author-interest">0</span> 명 관심
                     </div>
                     <div class="room-author-stat">
                         가입일 <span id="author-joined">-</span>

--- a/src/main/webapp/WEB-INF/views/rooms/map.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/map.jsp
@@ -90,9 +90,6 @@
                         <div class="room-card-stat">
                             👁 <span id="room-views">0</span>
                         </div>
-                        <div class="room-card-stat">
-                            ♡ <span id="room-interest">0</span>
-                        </div>
                         <div class="room-card-stat" id="room-status-text"></div>
                     </div>
                     <div class="room-card-actions">

--- a/src/main/webapp/resources/css/member/mypage-view.css
+++ b/src/main/webapp/resources/css/member/mypage-view.css
@@ -361,3 +361,41 @@
   font-size: 13px;
   margin-top: 4px;
 }
+.favorite-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.favorite-card {
+  display: flex;
+  gap: 16px;
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+  transition: transform .1s;
+}
+
+favorite-card:hover {
+  transform: translateY(-3px);
+}
+
+.favorite-thumb img {
+  width: 120px;
+  height: 90px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.favorite-info .favorite-title {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.favorite-empty {
+  padding: 20px;
+  text-align: center;
+  color: #aaa;
+}

--- a/src/main/webapp/resources/css/room/room-detail.css
+++ b/src/main/webapp/resources/css/room/room-detail.css
@@ -399,3 +399,9 @@
     color: #9ca3af;
     text-align: center;
 }
+/* ★ 찜하기(상세 페이지) active 상태 빨간 스타일 */
+#btn-like.active {
+    background: #fef2f2;   /* 연한 빨강 배경 */
+    border-color: #fecaca; /* 연한 빨강 테두리 */
+    color: #dc2626;        /* 진한 빨강 텍스트 */
+}

--- a/src/main/webapp/resources/js/member/mypageView.js
+++ b/src/main/webapp/resources/js/member/mypageView.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   try {
     await loadMyProfile();
+    await loadMyFavorites();
   } catch (e) {
     console.error("mypage view init error:", e);
   }
@@ -117,6 +118,83 @@ function renderChips(container, items, labelKey) {
     chip.classList.add("chip");
     chip.textContent = item[labelKey];
     container.appendChild(chip);
+  });
+}
+/**
+ * 내가 찜한 방 목록 불러오기
+ * GET /api/favorites/me
+ */
+async function loadMyFavorites() {
+  const container = document.getElementById("favoriteList");
+  if (!container) return;
+
+  container.innerHTML = "<p>관심 목록을 불러오는 중입니다...</p>";
+
+  try {
+    const res = await apiRequest("/api/favorites/me", { method: "GET" });
+    if (!res.ok) {
+      container.innerHTML = "<p>관심 목록을 불러오지 못했습니다.</p>";
+      return;
+    }
+
+    const list = await res.json();
+    renderFavoriteList(list);
+  } catch (e) {
+    console.error("loadMyFavorites error:", e);
+    container.innerHTML = "<p>관심 목록을 불러오지 못했습니다.</p>";
+  }
+}
+
+function renderFavoriteList(list) {
+  const container = document.getElementById("favoriteList");
+  if (!container) return;
+
+  if (!Array.isArray(list) || list.length === 0) {
+    container.innerHTML = `<p class="favorite-empty">아직 관심 등록한 방이 없습니다.</p>`;
+    return;
+  }
+
+  container.innerHTML = "";
+
+  list.forEach((room) => {
+    const roomId = room.roomId ?? room.room_id;
+    const title = room.roomTitle ?? room.room_title ?? "제목 없음";
+    const deposit = room.deposit;
+    const monthlyRent = room.monthlyRent ?? room.monthly_rent;
+    const thumbnail = room.thumbnailUrl ?? room.thumbnail_url;
+    const depositMan = deposit != null ? Math.round(deposit / 10000) : null;
+    const monthlyMan = monthlyRent != null ? Math.round(monthlyRent / 10000) : null;
+    const depositText = depositMan != null ? `${depositMan.toLocaleString()}만` : "-";
+    const monthlyText = monthlyMan != null ? `${monthlyMan.toLocaleString()}만` : "-";
+
+    const status = room.status;
+    let statusLabel = "";
+    if (status === "OPEN") statusLabel = "모집중";
+    else if (status === "RESERVED") statusLabel = "예약중";
+    else if (status === "CLOSED") statusLabel = "마감";
+    else if (status) statusLabel = status;
+
+    const card = document.createElement("div");
+    card.className = "favorite-card";
+
+    card.innerHTML = `
+      <div class="favorite-thumb">
+        <img src="${thumbnail || '/resources/img/no-image.png'}" alt="thumbnail">
+      </div>
+      <div class="favorite-info">
+        <h3 class="favorite-title">${title}</h3>
+        <p class="favorite-meta">
+          보증금 ${depositText} | 월세 ${monthlyText}
+        </p>
+        <span class="favorite-status">${statusLabel}</span>
+      </div>
+    `;
+
+    card.addEventListener("click", () => {
+      window.location.href = "/rooms/" + roomId;
+    });
+
+    container.appendChild(card);
   });
 }
 

--- a/src/main/webapp/resources/js/room/roomDetail.js
+++ b/src/main/webapp/resources/js/room/roomDetail.js
@@ -77,6 +77,19 @@ async function fetchCurrentMemberId() {
   }
 }
 
+
+// 찜 버튼 상태 적용 유틸
+function applyFavoriteButtonState(btn, favorited) {
+  if (!btn) return;
+  if (favorited) {
+    btn.classList.add("active");
+    btn.textContent = "찜 완료";
+  } else {
+    btn.classList.remove("active");
+    btn.textContent = "찜하기";
+  }
+}
+
 window.addEventListener("DOMContentLoaded", async () => {
   const {  roomId } = getRoomMeta();
 
@@ -85,7 +98,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     return;
   }
 
-  // 🔙 뒤로가기 버튼
+  // 뒤로가기 버튼
   const backBtn = document.getElementById("btn-back");
   if (backBtn) {
     backBtn.addEventListener("click", () => {
@@ -106,27 +119,49 @@ window.addEventListener("DOMContentLoaded", async () => {
   if (!room) return;
 
   // 작성자/로그인 여부에 따라 액션 버튼 노출
-  const ownerId = room.ownerId ?? room.owner_id ?? ownerIdFromMeta;
+  const ownerId = room.ownerId ?? room.owner_id ?? null;
   toggleActionButtons({ currentMemberId, ownerId });
 
   // ♡ 찜하기 버튼
   const likeBtn = document.getElementById("btn-like");
   if (likeBtn) {
-    likeBtn.addEventListener("click", () => {
-      requireLogin(async () => {
-        // TODO: 나중에 실제 찜 API 연동
-        // await apiRequest(`/api/favorites/${roomId}`, { method: "POST" });
+    // 1) 최초 상태 세팅: JSP에서 data-favorited="true|false" 내려줬다고 가정
+    const initialFavorited = !!(room.favorited ?? room.isFavorited);
+    applyFavoriteButtonState(likeBtn, initialFavorited);
 
-        // UI 토글
-        const isActive = likeBtn.classList.toggle("active");
-        likeBtn.textContent = isActive ? "찜 완료" : "찜하기";
+    // 2) 클릭 시 토글 + API 호출
+    likeBtn.addEventListener("click", async () => {
+      const ok = requireLogin();
+      if (!ok) return;
 
-        alert(
-          isActive
-            ? `roomId=${roomId} 방을 찜 목록에 추가 (API 연동 예정)`
-            : `roomId=${roomId} 방을 찜 목록에서 제거 (API 연동 예정)`
-        );
-      });
+      const currentlyFavorited = likeBtn.classList.contains("active");
+      const nextFavorited = !currentlyFavorited;
+
+      try {
+        if (nextFavorited) {
+          //  찜 추가
+          const res = await apiRequest(`/api/favorites/${roomId}`, {
+            method: "POST",
+          });
+          if (!res.ok) {
+            throw new Error("favorite failed");
+          }
+        } else {
+          //  찜 해제
+          const res = await apiRequest(`/api/favorites/${roomId}`, {
+            method: "DELETE",
+          });
+          // 404(이미 없음)는 그냥 무시해도 됨
+          if (!res.ok && res.status !== 404) {
+            throw new Error("unfavorite failed");
+          }
+        }
+
+        applyFavoriteButtonState(likeBtn, nextFavorited);
+      } catch (e) {
+        console.error("[room-detail] favorite toggle error:", e);
+        alert("관심 설정 중 오류가 발생했습니다.");
+      }
     });
   }
 
@@ -134,16 +169,16 @@ window.addEventListener("DOMContentLoaded", async () => {
   const chatBtn = document.getElementById("btn-start-chat");
   if (chatBtn) {
     chatBtn.addEventListener("click", () => {
-      requireLogin(async () => {
-        // TODO: 채팅방 생성 API 연동
-        // const res = await apiRequest("/api/chat/rooms", {
-        //   method: "POST",
-        //   body: JSON.stringify({ roomId }),
-        // });
+        const ok = requireLogin();
+        if (!ok) return;
+            // TODO: 채팅방 생성 API 연동
+            // const res = await apiRequest("/api/chat/rooms", {
+            //   method: "POST",
+            //   body: JSON.stringify({ roomId }),
+            // });
         alert(
           `roomId=${roomId} 방 작성자와 채팅을 시작하는 기능은 추후 WebSocket/채팅 API 연동 예정입니다.`
         );
-      });
     });
   }
 
@@ -306,13 +341,9 @@ function renderRoomDetail(room) {
 
   // --- 조회/관심수 (오른쪽 카드) ---
   const views = room.views ?? 0;
-  const interestCount = room.interestCount ?? room.interest_count ?? 0;
 
   const authorViewsEl = document.getElementById("author-views");
   if (authorViewsEl) authorViewsEl.innerText = views;
-
-  const authorInterestEl = document.getElementById("author-interest");
-  if (authorInterestEl) authorInterestEl.innerText = interestCount;
 
   // --- 작성자 정보 ---
   const authorName = room.ownerNickname ?? room.owner_nickname ?? "작성자";

--- a/src/main/webapp/resources/js/room/roomMap.js
+++ b/src/main/webapp/resources/js/room/roomMap.js
@@ -7,6 +7,7 @@ let clusterer;
 let selectedRoomId = null;
 let markers = [];
 let currentRooms = []; // /api/rooms/map 에서 받아온 방 목록
+let currentMemberId = null;
 
 function formatNumber(num) {
   if (num === null || num === undefined) return "-";
@@ -19,7 +20,7 @@ function cutText(text, maxLen) {
   return text.substring(0, maxLen) + "…";
 }
 
-window.addEventListener("load", () => {
+window.addEventListener("load", async () => {
   const container = document.getElementById("map");
   const options = {
     center: new kakao.maps.LatLng(37.5665, 126.9780), // 서울
@@ -34,6 +35,7 @@ window.addEventListener("load", () => {
     minLevel: 7,
   });
 
+  currentMemberId = await fetchCurrentMemberId();
   // 초기 1회
   fetchRoomsForCurrentBounds();
 
@@ -67,29 +69,62 @@ window.addEventListener("load", () => {
   window.location.href = `${contextPath}/rooms/${selectedRoomId}`;
 });
 
-  // 찜하기 (나중에 /api/favorites 연결 예정)
-  document
-    .getElementById("btn-favorite")
-    .addEventListener("click", async () => {
-      if (!selectedRoomId) return;
-      alert(
-        "찜하기 기능은 나중에 API 연동으로 구현할 예정입니다. (roomId=" +
-          selectedRoomId +
-          ")"
-      );
-      // 예: await apiRequest(`/api/favorites/${selectedRoomId}`, { method: "POST" });
-    });
+    const btnFavorite = document.getElementById("btn-favorite");
+    if (btnFavorite) {
+      btnFavorite.addEventListener("click", async () => {
+        if (!selectedRoomId) return;
 
+        // 로그인 여부 체크
+        const ok = requireLogin();
+        if (!ok) return;
+
+        const currentlyFavorited = btnFavorite.classList.contains("active");
+        const nextFavorited = !currentlyFavorited;
+
+        try {
+          if (nextFavorited) {
+            // 찜 추가
+            const res = await apiRequest(`/api/favorites/${selectedRoomId}`, {
+              method: "POST",
+            });
+            if (!res.ok) {
+              throw new Error("favorite failed");
+            }
+          } else {
+            // 찜 해제
+            const res = await apiRequest(`/api/favorites/${selectedRoomId}`, {
+              method: "DELETE",
+            });
+            // 404(이미 없음)는 그냥 무시
+            if (!res.ok && res.status !== 404) {
+              throw new Error("unfavorite failed");
+            }
+          }
+
+          applyFavoriteButtonState(btnFavorite, nextFavorited);
+        } catch (e) {
+          console.error("[rooms-map] favorite toggle error:", e);
+          alert("관심 설정 중 오류가 발생했습니다.");
+        }
+      });
+    }
   // 문의하기 (나중에 채팅방 생성 API 연동)
-  document.getElementById("btn-chat").addEventListener("click", async () => {
-    if (!selectedRoomId) return;
-    alert(
-      "문의하기(채팅)는 추후 WebSocket/채팅 API 연동 예정입니다. (roomId=" +
-        selectedRoomId +
-        ")"
-    );
-    // 예: await apiRequest("/api/chat/rooms", { method: "POST", body: JSON.stringify({ roomId: selectedRoomId, partnerId: ... }) });
-  });
+    const btnChat = document.getElementById("btn-chat");
+    if (btnChat) {
+      btnChat.addEventListener("click", async () => {
+        if (!selectedRoomId) return;
+
+        const ok = requireLogin();
+        if (!ok) return;
+
+        alert(
+          "문의하기(채팅)는 추후 WebSocket/채팅 API 연동 예정입니다. (roomId=" +
+            selectedRoomId +
+            ")"
+        );
+        // TODO: 나중에 채팅방 생성 API 연동
+      });
+    }
 });
 
 // ====== apiRequest 기반 비즈니스 로직 ======
@@ -120,6 +155,26 @@ async function fetchRoomsForCurrentBounds() {
     renderRoomMarkers(data);
   } catch (e) {
     console.error("지도용 방 목록 조회 중 오류:", e);
+  }
+}
+// 현재 로그인한 사용자 ID 조회 (비로그인 시 null)
+async function fetchCurrentMemberId() {
+  try {
+    const res = await apiRequest("/api/members/me", { method: "GET" });
+
+    if (!res.ok) {
+      // 401이면 비로그인
+      console.debug("[rooms-map] not logged in (status=", res.status, ")");
+      return null;
+    }
+
+    const data = await res.json();
+    const memberId = data.memberId ?? data.member_id ?? null;
+    console.debug("[rooms-map] currentMemberId =", memberId);
+    return memberId;
+  } catch (e) {
+    console.error("[rooms-map] fetchCurrentMemberId error:", e);
+    return null;
   }
 }
 
@@ -186,6 +241,10 @@ function renderRoomDetail(room) {
   document.getElementById("room-detail-body").style.display = "block";
   document.getElementById("room-detail-footer").style.display = "block";
 
+  // 찜 버튼 초기 상태 세팅
+  const btnFavorite = document.getElementById("btn-favorite");
+  const btnChat = document.getElementById("btn-chat");
+
   const imageUrls = room.imageUrls ?? room.image_urls;
   const imgEl = document.getElementById("room-image");
   if (imageUrls && imageUrls.length > 0) {
@@ -200,7 +259,7 @@ function renderRoomDetail(room) {
   document.getElementById("room-address").innerText =
     room.address || "";
 
-  // ✅ 월세 / 보증금 (여기 전부 수정됨)
+  //  월세 / 보증금 (여기 전부 수정됨)
   const monthlyRent = room.monthlyRent ?? room.monthly_rent;
   const deposit = room.deposit;
 
@@ -214,7 +273,7 @@ function renderRoomDetail(room) {
 
   document.getElementById("room-price").innerText = monthlyText;
 
-  // ✅ 입주일 / 최대 인원 / 층·면적
+  //  입주일 / 최대 인원 / 층·면적
   const availableFrom = room.availableFrom ?? room.available_from;
   const maxRoommates = room.maxRoommates ?? room.max_roommates;
   const floor = room.floor;
@@ -231,21 +290,17 @@ function renderRoomDetail(room) {
       area != null ? area + "㎡" : "?㎡"
     }`;
 
-  // ✅ 설명
+  // 설명
   const content = room.content;
   document.getElementById("room-content").innerText =
     cutText(content || "", 120);
 
-  // ✅ 조회수 / 찜수 / 상태
+  //  조회수 / 상태
   const views = room.views;
-  const interestCount = room.interestCount ?? room.interest_count;
   const status = room.status;
 
   document.getElementById("room-views").innerText =
     views != null ? views : 0;
-
-  document.getElementById("room-interest").innerText =
-    interestCount != null ? interestCount : 0;
 
   const statusTextEl = document.getElementById("room-status-text");
   if (status === "OPEN") {
@@ -272,6 +327,24 @@ function renderRoomDetail(room) {
     span.innerText = text;
     chipContainer.appendChild(span);
   });
+
+  // 내가 올린 방이면 찜/문의 버튼 숨기기
+  const ownerId = room.ownerId ?? room.owner_id;
+
+  if (ownerId && currentMemberId && String(ownerId) === String(currentMemberId)) {
+    // 내 방인 경우 → 찜/문의 숨김
+    if (btnFavorite) btnFavorite.style.display = "none";
+    if (btnChat) btnChat.style.display = "none";
+  } else {
+    if (btnFavorite) {
+      btnFavorite.style.display = "inline-flex";
+      const initialFavorited = !!(room.favorited ?? room.isFavorited);
+      applyFavoriteButtonState(btnFavorite, initialFavorited);
+    }
+    if (btnChat) {
+      btnChat.style.display = "inline-flex";
+    }
+  }
 }
 
 function renderNearbyRooms(selectedRoom) {
@@ -369,4 +442,15 @@ function renderNearbyRooms(selectedRoom) {
     item.appendChild(meta);
     listEl.appendChild(item);
   });
+}
+
+function applyFavoriteButtonState(btn, favorited) {
+  if (!btn) return;
+  if (favorited) {
+    btn.classList.add("active");
+    btn.textContent = "찜 완료";
+  } else {
+    btn.classList.remove("active");
+    btn.textContent = "♡ 찜하기";
+  }
 }


### PR DESCRIPTION
개요

관심목록(찜) 기능을 백엔드·프론트엔드 전 구간에 걸쳐 완전히 구현했습니다.
또한 상세 페이지, 지도 페이지, 마이페이지와 연동하여 사용자가 임의의 방을 찜/해제하고 자신의 리스트를 조회할 수 있도록 기능을 통합했습니다.

 주요 기능 구현 내용
1) 관심목록 REST API 구현

POST /api/favorites/{roomId} → 방 찜하기

DELETE /api/favorites/{roomId} → 방 찜 해제

GET /api/favorites/me → 내가 찜한 방 목록 조회

2) Service / Repository 리팩터링

FavoriteSerivce / FavoriteSerivceImp 삭제 및 새로운 FavoriteService·FavoriteServiceImp 생성

기존 request/response DTO 구조 정리

Favorite.xml 새로 정리 및 불필요 SQL 제거

MemberId + RoomId 기반 중복 등록 방지 처리

3) Room 상세 페이지 연동 (roomDetail.js)

기존의 임시 alert 토글 삭제

실제 찜 API 연동

찜 버튼 상태(찜하기 ↔ 찜 완료) UI 동기화

내가 올린 방일 경우 → 찜 / 문의 버튼 숨김 처리

4) 지도 페이지(map.jsp / roomMap.js) 연동

지도 상세 카드에서도 찜 버튼이 동작하도록 API 연동

내가 올린 방이면 찜/문의 버튼 숨김

상세 보기 클릭 시 requireLogin 적용

상세 카드에 ownerId 기반으로 조건 처리 로직 추가

5) 마이페이지(mypage.jsp / mypageView.js) 연동

관심목록 탭 추가

내가 찜한 방 목록 카드 리스트 UI 구성

API 연동하여 동적 렌더링 가능하도록 구현

기존 CSS 분리 및 정제 (mypage-view.css)

6) RoomDetailResponse 확장

찜 여부(isFavorited) 제거 — 프론트에서 목록 기반 판단

Room ownerId / ownerName / ownerPhotoUrl 제공

관심수(interestCount) 필드 조정

7) 기타 정비

FavoriteRequest / FavoriteResponse 불필요 DTO 삭제

SecurityConfig에 favorites API 허용 추가

View(JSP) 정리

room-detail.css, roomMap.js, roomDetail.js UI 보완

Mapper 경로 favorite/ 로 정리