### PR TITLE
feat: 회원가입·방등록 임시 이미지 업로드 및 저장 확정 구조 구현

### DIFF
--- a/src/main/java/com/roommate/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/roommate/domain/auth/dto/request/LoginRequest.java
@@ -1,5 +1,7 @@
 package com.roommate.domain.auth.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +10,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/roommate/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,11 +1,14 @@
 package com.roommate.domain.auth.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/roommate/domain/auth/dto/request/SignUpRequest.java
@@ -1,5 +1,7 @@
 package com.roommate.domain.auth.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
 import lombok.Getter;
@@ -9,6 +11,7 @@ import lombok.Setter;
 import javax.validation.constraints.*;
 import java.util.List;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -41,5 +44,6 @@ public class SignUpRequest {
     private List<Long> preferenceIds;
     private List<Long> petIds;
 
+    private String signupKey;
     private Long profileTempFileId;
 }

--- a/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/roommate/domain/auth/service/AuthServiceImpl.java
@@ -129,14 +129,15 @@ public class AuthServiceImpl implements AuthService {
 
         validateEmailDuplication(signUpRequest.getEmail());
 
-        if (signUpRequest.getProfileTempFileId() != null) {
-            String photoUrl = tempUploadFileService.useTempFile(signUpRequest.getProfileTempFileId());
-            signUpRequest.setPhotoUrl(photoUrl);
-        }
-
         MemberEntity memberEntity = createMemberFromSignUpRequest(signUpRequest);
         memberRepository.save(memberEntity);
         Long memberId = memberEntity.getMemberId();
+
+        if (signUpRequest.getProfileTempFileId() != null && signUpRequest.getSignupKey() != null) {
+            String finalPhotoUrl = tempUploadFileService.useTempFileForSignup(signUpRequest.getProfileTempFileId(),signUpRequest.getSignupKey(),memberId);
+            memberRepository.updatePhotoUrl(memberId, finalPhotoUrl);
+        }
+
 
         if (signUpRequest.getHobbyIds() != null && !signUpRequest.getHobbyIds().isEmpty()) {
             memberHobbyRepository.insertMemberHobbies(memberId, signUpRequest.getHobbyIds());

--- a/src/main/java/com/roommate/domain/favorite/dto/request/FavoriteRequest.java
+++ b/src/main/java/com/roommate/domain/favorite/dto/request/FavoriteRequest.java
@@ -1,11 +1,12 @@
 package com.roommate.domain.favorite.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/file/controller/FileUploadRestController.java
+++ b/src/main/java/com/roommate/domain/file/controller/FileUploadRestController.java
@@ -1,13 +1,13 @@
 package com.roommate.domain.file.controller;
 
+import com.roommate.common.security.UserDetailsImpl;
 import com.roommate.domain.file.dto.response.TempUploadFileResponse;
 import com.roommate.domain.file.entity.TempUploadFileEntity;
 import com.roommate.domain.file.service.TempUploadFileService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -17,9 +17,27 @@ public class FileUploadRestController {
 
     private final TempUploadFileService tempUploadFileService;
 
+    @PutMapping("/temp/profile-signup")
+    public TempUploadFileResponse uploadTempProfileForSignup(@RequestParam("signup_key") String signupKey, @RequestParam("file") MultipartFile file) {
+        TempUploadFileEntity e = tempUploadFileService.uploadTempProfileImageForSignup(signupKey, file);
+        return new TempUploadFileResponse(e.getTempFileId(), e.getTempPath());
+    }
+
     @PutMapping("/temp/profile")
-    public TempUploadFileResponse uploadTempProfileImage(@RequestParam("file") MultipartFile file) {
-        TempUploadFileEntity tempUploadFileEntity = tempUploadFileService.uploadTempProfileImage(file);
+    public TempUploadFileResponse uploadTempProfileImage(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam("file") MultipartFile file) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileService.uploadTempProfileImage(userDetails.getMemberId(), file);
         return new TempUploadFileResponse(tempUploadFileEntity.getTempFileId(), tempUploadFileEntity.getTempPath());
+    }
+
+    @PutMapping("/temp/room")
+    public TempUploadFileResponse uploadTempRoomImage(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam("file") MultipartFile file) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileService.uploadTempRoomImage(userDetails.getMemberId(), file);
+        return new TempUploadFileResponse(tempUploadFileEntity.getTempFileId(), tempUploadFileEntity.getTempPath());
+    }
+    // FileUploadRestController에 추가
+    @DeleteMapping("/temp")
+    public ResponseEntity<Void> deleteTempFile(@RequestParam("signup_key") String signupKey, @RequestParam("temp_file_id") Long tempFileId) {
+        tempUploadFileService.deleteTempFile(tempFileId,signupKey);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/roommate/domain/file/dto/request/TempUploadFileUseRequest.java
+++ b/src/main/java/com/roommate/domain/file/dto/request/TempUploadFileUseRequest.java
@@ -1,9 +1,12 @@
 package com.roommate.domain.file.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/file/entity/TempUploadFileEntity.java
+++ b/src/main/java/com/roommate/domain/file/entity/TempUploadFileEntity.java
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Builder
 public class TempUploadFileEntity {
     private Long tempFileId;
+    private Long memberId;
+    private String signupKey;
     private String originalName;
     private String tempPath;
     private Integer used;

--- a/src/main/java/com/roommate/domain/file/repository/TempUploadFileRepository.java
+++ b/src/main/java/com/roommate/domain/file/repository/TempUploadFileRepository.java
@@ -12,11 +12,17 @@ public interface TempUploadFileRepository {
 
     TempUploadFileEntity findById(@Param("tempFileId") Long tempFileId);
 
+    TempUploadFileEntity findByIdAndMemberId(@Param("tempFileId") Long tempFileId, @Param("memberId") Long memberId);
+
+    TempUploadFileEntity findByIdAndSignupKey(@Param("tempFileId") Long tempFileId, @Param("signupKey") String signupKey);
+
     List<TempUploadFileEntity> findExpired(@Param("threshold") LocalDateTime threshold);
 
     void save(TempUploadFileEntity entity);
 
     void updateUsed(TempUploadFileEntity entity);
+
+    void updateUsedAndPath(@Param("tempFileId") Long tempFileId, @Param("used") Integer used, @Param("tempPath") String tempPath);
 
     void deleteById(@Param("tempFileId") Long tempFileId);
 

--- a/src/main/java/com/roommate/domain/file/service/FileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/FileStorageService.java
@@ -11,4 +11,8 @@ public interface FileStorageService {
     String storeTempImage(String category, MultipartFile multipartFile);
 
     void deleteByUrl(String url);
+
+    String moveTempProfileToProfile(Long memberId, String tempUrl);
+
+    String moveTempRoomToRoom(Long roomId, String tempUrl);
 }

--- a/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
@@ -9,6 +9,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 @Service
 @RequiredArgsConstructor
@@ -94,5 +98,68 @@ public class LocalFileStorageService implements FileStorageService {
                 System.out.println("프로필 이미지 삭제 실패: " + file.getAbsolutePath());
             }
         }
+    }
+
+    @Override
+    public String moveTempProfileToProfile(Long memberId, String tempUrl) {
+        return moveTempToPermanent("temp/profile", "profile", "member-" + memberId, tempUrl);
+    }
+
+    @Override
+    public String moveTempRoomToRoom(Long roomId, String tempUrl) {
+        return moveTempToPermanent("temp/room", "room", "room-" + roomId, tempUrl);
+    }
+
+    private String moveTempToPermanent(String expectedTempDir, String targetDir, String prefix, String tempUrl) {
+        if (tempUrl == null || !tempUrl.startsWith("/upload/")) {
+            throw new ApiException(ErrorCode.FILE_PATH_INVALID);
+        }
+
+        String relative = tempUrl.substring("/upload/".length()); // ex) temp/profile/xxx.png
+        if (!relative.startsWith(expectedTempDir + "/")) {
+            // profile temp를 room으로 옮기려는 시도 등 방지
+            throw new ApiException(ErrorCode.FILE_PATH_INVALID);
+        }
+
+        File srcFile = new File(uploadRootPath, relative);
+        if (!srcFile.exists() || !srcFile.isFile()) {
+            throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        }
+
+        // target dir 준비
+        File destDir = new File(uploadRootPath, targetDir);
+        if (!destDir.exists() && !destDir.mkdirs()) {
+            throw new ApiException(ErrorCode.FILE_PATH_INVALID);
+        }
+
+        // 확장자 유지
+        String srcName = srcFile.getName();
+        String ext = "";
+        int dot = srcName.lastIndexOf(".");
+        if (dot >= 0) ext = srcName.substring(dot);
+
+        String destName = prefix + "-" + System.currentTimeMillis() + ext;
+        File destFile = new File(destDir, destName);
+
+        Path src = srcFile.toPath();
+        Path dest = destFile.toPath();
+
+        // copy + delete
+        try {
+            try {
+                Files.move(src, dest, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException ex) {
+                Files.copy(src, dest, StandardCopyOption.REPLACE_EXISTING);
+                boolean deleted = srcFile.delete();
+                if (!deleted) {
+                    // 복사는 됐는데 원본 삭제 실패하면 temp에 남을 수 있음(나중에 정리 필요)
+                    System.out.println("[WARN] temp 파일 삭제 실패: " + srcFile.getAbsolutePath());
+                }
+            }
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        return "/upload/" + targetDir + "/" + destName;
     }
 }

--- a/src/main/java/com/roommate/domain/file/service/TempUploadFileService.java
+++ b/src/main/java/com/roommate/domain/file/service/TempUploadFileService.java
@@ -5,9 +5,19 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface TempUploadFileService {
 
-    public TempUploadFileEntity uploadTempProfileImage(MultipartFile file);
+    //회원가입전
+    public TempUploadFileEntity uploadTempProfileImageForSignup(String signupKey, MultipartFile file);
 
-    public String useTempFile(Long tempFileId);
+    public String useTempFileForSignup(Long tempFileId, String signupKey, Long memberId);
+
+    public void deleteTempFile(Long tempFileId, String signupKey);
+    //로그인후
+    public TempUploadFileEntity uploadTempProfileImage(Long memberId, MultipartFile file);
+
+    public TempUploadFileEntity uploadTempRoomImage(Long memberId, MultipartFile file);
 
     public void cleanupExpiredTempFiles(int hours);
+
+    String useTempFileForRoom(Long tempFileId, Long memberId, Long roomId);
+
 }

--- a/src/main/java/com/roommate/domain/file/service/TempUploadFileServiceImpl.java
+++ b/src/main/java/com/roommate/domain/file/service/TempUploadFileServiceImpl.java
@@ -19,13 +19,54 @@ public class TempUploadFileServiceImpl implements TempUploadFileService {
     private final FileStorageService fileStorageService;
     private final TempUploadFileRepository tempUploadFileRepository;
 
-
     @Override
     @Transactional
-    public TempUploadFileEntity uploadTempProfileImage(MultipartFile file) {
+    public TempUploadFileEntity uploadTempProfileImageForSignup(String signupKey, MultipartFile file) {
+        if (signupKey == null || signupKey.trim().isEmpty()) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (signupKey.length() != 36) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
+        try {
+            java.util.UUID.fromString(signupKey);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+
         String url = fileStorageService.storeTempImage("profile", file);
 
         TempUploadFileEntity tempUploadFileEntity = new TempUploadFileEntity();
+        tempUploadFileEntity.setMemberId(null);
+        tempUploadFileEntity.setSignupKey(signupKey);
+        tempUploadFileEntity.setOriginalName(file.getOriginalFilename());
+        tempUploadFileEntity.setTempPath(url);
+        tempUploadFileEntity.setUsed(0);
+
+        tempUploadFileRepository.save(tempUploadFileEntity);
+        return tempUploadFileEntity;
+    }
+
+    @Override
+    @Transactional
+    public String useTempFileForSignup(Long tempFileId, String signupKey, Long memberId) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileRepository.findByIdAndSignupKey(tempFileId, signupKey);
+        if (tempUploadFileEntity == null) throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        if (tempUploadFileEntity.getUsed() != null && tempUploadFileEntity.getUsed() == 1) throw new ApiException(ErrorCode.FILE_ALREADY_USED);
+        String finalUrl = fileStorageService.moveTempProfileToProfile(memberId, tempUploadFileEntity.getTempPath());
+        tempUploadFileRepository.deleteById(tempFileId);
+        return finalUrl;
+    }
+
+    @Override
+    @Transactional
+    public TempUploadFileEntity uploadTempProfileImage(Long memberId, MultipartFile file) {
+        String url = fileStorageService.storeTempImage("profile", file);
+        TempUploadFileEntity tempUploadFileEntity = new TempUploadFileEntity();
+        tempUploadFileEntity.setMemberId(memberId);
+        tempUploadFileEntity.setSignupKey(null);
         tempUploadFileEntity.setOriginalName(file.getOriginalFilename());
         tempUploadFileEntity.setTempPath(url);
         tempUploadFileEntity.setUsed(0);
@@ -35,18 +76,16 @@ public class TempUploadFileServiceImpl implements TempUploadFileService {
 
     @Override
     @Transactional
-    public String useTempFile(Long tempFileId) {
-        TempUploadFileEntity tempUploadFileEntity = tempUploadFileRepository.findById(tempFileId);
-        if (tempUploadFileEntity == null) {
-            throw new ApiException(ErrorCode.FILE_NOT_FOUND);
-        }
-        if (tempUploadFileEntity.getUsed() != null && tempUploadFileEntity.getUsed() == 1) {
-            throw new ApiException(ErrorCode.FILE_ALREADY_USED);
-        }
-
-        tempUploadFileEntity.setUsed(1);
-        tempUploadFileRepository.updateUsed(tempUploadFileEntity);
-        return tempUploadFileEntity.getTempPath();
+    public TempUploadFileEntity uploadTempRoomImage(Long memberId, MultipartFile file) {
+        String url = fileStorageService.storeTempImage("room", file);
+        TempUploadFileEntity tempUploadFileEntity = new TempUploadFileEntity();
+        tempUploadFileEntity.setMemberId(memberId);
+        tempUploadFileEntity.setSignupKey(null);
+        tempUploadFileEntity.setOriginalName(file.getOriginalFilename());
+        tempUploadFileEntity.setTempPath(url);
+        tempUploadFileEntity.setUsed(0);
+        tempUploadFileRepository.save(tempUploadFileEntity);
+        return tempUploadFileEntity;
     }
 
     @Override
@@ -59,5 +98,26 @@ public class TempUploadFileServiceImpl implements TempUploadFileService {
             fileStorageService.deleteByUrl(e.getTempPath());
             tempUploadFileRepository.deleteById(e.getTempFileId());
         }
+    }
+
+    @Override
+    @Transactional
+    public String useTempFileForRoom(Long tempFileId, Long memberId, Long roomId) {
+        TempUploadFileEntity tempUploadFile = tempUploadFileRepository.findByIdAndMemberId(tempFileId, memberId);
+        if (tempUploadFile == null) throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+        if (tempUploadFile.getUsed() != null && tempUploadFile.getUsed() == 1) throw new ApiException(ErrorCode.FILE_ALREADY_USED);
+        String finalUrl = fileStorageService.moveTempRoomToRoom(roomId, tempUploadFile.getTempPath());
+        tempUploadFileRepository.deleteById(tempFileId);
+        return finalUrl;
+    }
+
+    @Override
+    @Transactional
+    public void deleteTempFile(Long tempFileId, String signupKey) {
+        TempUploadFileEntity tempUploadFileEntity = tempUploadFileRepository.findByIdAndSignupKey(tempFileId, signupKey);
+        if (tempUploadFileEntity == null) return; // 없으면 그냥 종료(프론트 UX상 OK)
+
+        fileStorageService.deleteByUrl(tempUploadFileEntity.getTempPath()); // 실제 파일 삭제
+        tempUploadFileRepository.deleteById(tempFileId); // DB 삭제
     }
 }

--- a/src/main/java/com/roommate/domain/member/dto/request/MemberPasswordChangeRequest.java
+++ b/src/main/java/com/roommate/domain/member/dto/request/MemberPasswordChangeRequest.java
@@ -1,5 +1,7 @@
 package com.roommate.domain.member.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,7 @@ import lombok.Setter;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/member/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/roommate/domain/member/dto/request/MemberProfileUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.roommate.domain.member.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.member.entity.MemberDrinkingEnum;
 import com.roommate.domain.member.entity.MemberSmokingEnum;
 import lombok.Getter;
@@ -8,6 +10,7 @@ import lombok.Setter;
 
 import java.util.List;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/member/dto/request/WorkTypeRequest.java
+++ b/src/main/java/com/roommate/domain/member/dto/request/WorkTypeRequest.java
@@ -1,9 +1,12 @@
 package com.roommate.domain.member.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -27,4 +27,7 @@ public interface MemberRepository {
 
     void updatePassword(@Param("memberId") Long memberId, @Param("password") String encodedPassword);
 
+    void updatePhotoUrl(@Param("memberId") Long memberId, @Param("photoUrl") String photoUrl);
+
+
 }

--- a/src/main/java/com/roommate/domain/room/controller/RoomRestController.java
+++ b/src/main/java/com/roommate/domain/room/controller/RoomRestController.java
@@ -4,6 +4,7 @@ import com.roommate.common.security.UserDetailsImpl;
 import com.roommate.domain.room.dto.request.RoomCreateRequest;
 import com.roommate.domain.room.dto.request.RoomStatusUpdateRequest;
 import com.roommate.domain.room.dto.request.RoomUpdateRequest;
+import com.roommate.domain.room.dto.response.MyRoomListItemResponse;
 import com.roommate.domain.room.dto.response.RoomDetailResponse;
 import com.roommate.domain.room.dto.response.RoomMapItemResponse;
 import com.roommate.domain.room.service.RoomService;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -35,9 +37,16 @@ public class RoomRestController {
 
     // 방 등록
     @PostMapping
-    public Long createRoom(@RequestBody RoomCreateRequest request, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public Long createRoom(@Valid @RequestBody RoomCreateRequest request, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Long memberId = userDetails.getMemberId();
         return roomService.createRoom(request, memberId);
+    }
+
+    // 방 조회 (작성자)
+    @GetMapping("/me")
+    public List<MyRoomListItemResponse> getMyRooms(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Long memberId = userDetails.getMemberId();
+        return roomService.getMyRooms(memberId);
     }
 
     // 방 수정 (작성자만)

--- a/src/main/java/com/roommate/domain/room/controller/RoomTypeRestController.java
+++ b/src/main/java/com/roommate/domain/room/controller/RoomTypeRestController.java
@@ -1,0 +1,23 @@
+package com.roommate.domain.room.controller;
+
+import com.roommate.domain.room.dto.response.RoomTypeResponse;
+import com.roommate.domain.room.service.RoomTypeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/room-types")
+@RequiredArgsConstructor
+public class RoomTypeRestController {
+
+    private final RoomTypeService roomTypeService;
+
+    @GetMapping
+    public List<RoomTypeResponse> getRoomTypes() {
+        return roomTypeService.getRoomTypes();
+    }
+}

--- a/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
+++ b/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
@@ -27,28 +27,27 @@ public class RoomViewController {
     @GetMapping("")
     public String roomMainPage(Model model) {
 
-        model.addAttribute("kakaoJsKey",kakaoJsKey);
+        model.addAttribute("kakaoJsKey", kakaoJsKey);
         return "rooms/main";
     }
 
     /**
      * 지도에서 찾기 페이지
-     *
+     * <p>
      * 왜 이렇게 했는지:
      * - 이 컨트롤러는 "화면(View)"만 반환하고
-     *   실제 데이터는 JS가 REST API(/api/rooms/**)로 가져가도록 분리.
+     * 실제 데이터는 JS가 REST API(/api/rooms/**)로 가져가도록 분리.
      * - 그래서 Model에 데이터를 따로 넣을 필요가 없음.
      */
     @GetMapping("/map")
     public String showRoomMapPage(Model model) {
         // /WEB-INF/views/room/map.jsp
-        model.addAttribute("kakaoJsKey",kakaoJsKey);
+        model.addAttribute("kakaoJsKey", kakaoJsKey);
         return "rooms/map";
     }
 
     /**
      * 방 상세 페이지 (추후 구현용)
-     *
      */
     @GetMapping("/{roomId}")
     public String roomDetailView(@PathVariable Long roomId, Model model) {
@@ -56,5 +55,13 @@ public class RoomViewController {
         model.addAttribute("roomId", roomId);
         model.addAttribute("kakaoJsKey", kakaoJsKey);
         return "rooms/detail"; // /WEB-INF/views/rooms/detail.jsp
+    }
+
+    /**
+     * 방 등록 페이지
+     */
+    @GetMapping("/roomCreate")
+    public String roomCreateView(){
+        return "rooms/roomCreate";
     }
 }

--- a/src/main/java/com/roommate/domain/room/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/roommate/domain/room/dto/request/RoomCreateRequest.java
@@ -1,29 +1,42 @@
 package com.roommate.domain.room.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 import java.time.LocalDate;
 import java.util.List;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor
 public class RoomCreateRequest {
+    @NotBlank
     private String title;
+    @NotBlank
     private String content;
+    @NotNull
     private Long roomTypeId;
+    @NotNull
+    @PositiveOrZero
     private Double monthlyRent;
+    @NotNull
+    @PositiveOrZero
     private Double deposit;
     private Float areaM2;
     private Integer floor;
+    @NotBlank
     private String address;
     private String legalDong;
     private String landNumber;
-    private Double lat;
-    private Double lng;
     private LocalDate availableFrom;
     private Integer maxRoommates;
     private List<String> imageUrls;
+    private List<Long> tempFileIds;
 }

--- a/src/main/java/com/roommate/domain/room/dto/request/RoomStatusUpdateRequest.java
+++ b/src/main/java/com/roommate/domain/room/dto/request/RoomStatusUpdateRequest.java
@@ -1,10 +1,13 @@
 package com.roommate.domain.room.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.roommate.domain.room.entity.RoomStatusEnum;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/roommate/domain/room/dto/request/RoomUpdateRequest.java
+++ b/src/main/java/com/roommate/domain/room/dto/request/RoomUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.roommate.domain.room.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,7 @@ import lombok.Setter;
 import java.time.LocalDate;
 import java.util.List;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -21,9 +24,8 @@ public class RoomUpdateRequest {
     private String address;
     private String legalDong;
     private String landNumber;
-    private Double lat;
-    private Double lng;
     private LocalDate availableFrom;
     private Integer maxRoommates;
     private List<String> imageUrls;
+    private List<Long> tempFileIds;
 }

--- a/src/main/java/com/roommate/domain/room/dto/response/MyRoomListItemResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/MyRoomListItemResponse.java
@@ -1,0 +1,23 @@
+package com.roommate.domain.room.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.roommate.domain.room.entity.RoomStatusEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class MyRoomListItemResponse {
+    private final Long roomId;
+    private final String title;
+    private final String address;
+    private final Double monthlyRent;
+    private final Double deposit;
+    private final RoomStatusEnum status;
+    private final String thumbnailUrl;
+    private final LocalDateTime roomCreatedAt;
+}

--- a/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
@@ -19,7 +19,7 @@ public class RoomDetailResponse {
     private final String title;
     private final String content;
     private final Long roomTypeId;
-    private String roomTypeName;
+    private final String roomTypeName;
     private final Double monthlyRent;
     private final Double deposit;
     private final Float areaM2;

--- a/src/main/java/com/roommate/domain/room/dto/response/RoomTypeResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/RoomTypeResponse.java
@@ -1,15 +1,15 @@
-package com.roommate.domain.member.dto.request;
+package com.roommate.domain.room.dto.response;
+
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Getter
-@Setter
-@NoArgsConstructor
-public class MemberRequest {
-    private Long memberId;
+@AllArgsConstructor
+public class RoomTypeResponse {
+    private final Long roomTypeId;
+    private final String roomTypeName;
 }

--- a/src/main/java/com/roommate/domain/room/entity/RoomDetailEntity.java
+++ b/src/main/java/com/roommate/domain/room/entity/RoomDetailEntity.java
@@ -34,6 +34,6 @@ public class RoomDetailEntity {
     private LocalDateTime roomUpdatedAt;
     // 작성자
     private Long ownerId;
-    private String ownerNickname;
+    private String ownerName;
     private String ownerPhotoUrl;
 }

--- a/src/main/java/com/roommate/domain/room/entity/RoomTypeEntity.java
+++ b/src/main/java/com/roommate/domain/room/entity/RoomTypeEntity.java
@@ -1,0 +1,16 @@
+package com.roommate.domain.room.entity;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class RoomTypeEntity {
+    private Long roomTypeId;
+    private String roomTypeName;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/roommate/domain/room/repository/RoomImageRepository.java
+++ b/src/main/java/com/roommate/domain/room/repository/RoomImageRepository.java
@@ -8,19 +8,19 @@ import java.util.List;
 @Mapper
 public interface RoomImageRepository {
     /**
-     * ✅ 특정 방의 기존 이미지 전체 삭제
+     *  특정 방의 기존 이미지 전체 삭제
      * 왜: 수정 시 기존 이미지를 전부 지우고 새 이미지로 교체하는 정책
      */
     void deleteByRoomId(@Param("roomId") Long roomId);
 
     /**
-     * ✅ 단건 이미지 저장
+     *  단건 이미지 저장
      * 왜: 여러 장 저장 시 반복 호출용
      */
     void insertRoomImage(@Param("roomId") Long roomId, @Param("imageUrl") String imageUrl, @Param("sortOrder") Integer sortOrder);
 
     /**
-     * ✅ 방의 이미지 URL 목록 조회 (상세 조회용)
+     *  방의 이미지 URL 목록 조회 (상세 조회용)
      */
     List<String> findImageUrlsByRoomId(@Param("roomId") Long roomId);
 

--- a/src/main/java/com/roommate/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/roommate/domain/room/repository/RoomRepository.java
@@ -1,5 +1,6 @@
 package com.roommate.domain.room.repository;
 
+import com.roommate.domain.room.dto.response.MyRoomListItemResponse;
 import com.roommate.domain.room.entity.RoomDetailEntity;
 import com.roommate.domain.room.entity.RoomEntity;
 import com.roommate.domain.room.entity.RoomMapItemEntity;
@@ -29,4 +30,7 @@ public interface RoomRepository {
 
     // 상세 조회용 (조인된 결과를 response DTO로 바로 받을 수도 있음)
     RoomDetailEntity findDetailById(@Param("roomId") Long roomId);
+
+    //방 등록 조회
+    List<MyRoomListItemResponse> findMyRooms(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/roommate/domain/room/repository/RoomTypeRepository.java
+++ b/src/main/java/com/roommate/domain/room/repository/RoomTypeRepository.java
@@ -1,0 +1,19 @@
+package com.roommate.domain.room.repository;
+
+import com.roommate.domain.room.entity.RoomTypeEntity;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface RoomTypeRepository {
+    List<RoomTypeEntity> findAll();
+
+    RoomTypeEntity findById(Long roomTypeId);
+
+    void insert(RoomTypeEntity entity);
+
+    void update(RoomTypeEntity entity);
+
+    void delete(Long roomTypeId);
+}

--- a/src/main/java/com/roommate/domain/room/service/RoomImageService.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomImageService.java
@@ -1,0 +1,19 @@
+package com.roommate.domain.room.service;
+
+import java.util.List;
+
+public interface RoomImageService {
+    /**
+     * 방 등록 시: temp 파일들을 "사용 처리"하고(room 소유자 검증 포함),
+     * room_image 테이블에 순서대로 저장한다.
+     */
+    void attachTempImagesToRoom(Long roomId, Long memberId, List<Long> tempFileIds);
+
+    /**
+     * 방 수정 시: 기존 이미지를 전체 교체한다.
+     * (지금 정책 그대로 유지)
+     */
+    void replaceRoomImages(Long roomId, List<String> imageUrls);
+
+    List<String> findImageUrlsByRoomId(Long roomId);
+}

--- a/src/main/java/com/roommate/domain/room/service/RoomImageServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomImageServiceImpl.java
@@ -1,0 +1,61 @@
+package com.roommate.domain.room.service;
+
+import com.roommate.domain.file.service.TempUploadFileService;
+import com.roommate.domain.room.repository.RoomImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoomImageServiceImpl implements RoomImageService{
+    private final RoomImageRepository roomImageRepository;
+    private final TempUploadFileService tempUploadFileService;
+
+    @Override
+    @Transactional
+    public void attachTempImagesToRoom(Long roomId, Long memberId, List<Long> tempFileIds) {
+        if (tempFileIds == null || tempFileIds.isEmpty()) {
+            // 이미지 없는 케이스: 기존 이미지도 없을 거라 그냥 종료
+            return;
+        }
+
+        List<String> imageUrls = new ArrayList<>();
+
+        for (Long tempFileId : tempFileIds) {
+            // 왜: 남의 temp 파일 도용 방지 + used=1 확정
+            String url = tempUploadFileService.useTempFileForRoom(tempFileId, memberId,roomId);
+            imageUrls.add(url);
+        }
+
+        replaceRoomImages(roomId, imageUrls);
+    }
+
+    @Override
+    @Transactional
+    public void replaceRoomImages(Long roomId, List<String> imageUrls) {
+        // 1) 기존 이미지 전체 삭제
+        roomImageRepository.deleteByRoomId(roomId);
+
+        // 2) 새 이미지가 없으면 그대로 종료
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+
+        // 3) 새 이미지 순서대로 저장 (0부터 sort_order)
+        for (int i = 0; i < imageUrls.size(); i++) {
+            roomImageRepository.insertRoomImage(roomId, imageUrls.get(i), i);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> findImageUrlsByRoomId(Long roomId) {
+        return roomImageRepository.findImageUrlsByRoomId(roomId);
+    }
+}

--- a/src/main/java/com/roommate/domain/room/service/RoomService.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomService.java
@@ -3,6 +3,7 @@ package com.roommate.domain.room.service;
 import com.roommate.domain.room.dto.request.RoomCreateRequest;
 import com.roommate.domain.room.dto.request.RoomStatusUpdateRequest;
 import com.roommate.domain.room.dto.request.RoomUpdateRequest;
+import com.roommate.domain.room.dto.response.MyRoomListItemResponse;
 import com.roommate.domain.room.dto.response.RoomDetailResponse;
 import com.roommate.domain.room.dto.response.RoomMapItemResponse;
 
@@ -22,4 +23,5 @@ public interface RoomService {
 
     public List<RoomMapItemResponse> getRoomsForMap(double north, double south, double east, double west, int zoom);
 
+    public List<MyRoomListItemResponse> getMyRooms(Long memberId);
 }

--- a/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
@@ -7,13 +7,13 @@ import com.roommate.domain.member.service.MemberService;
 import com.roommate.domain.room.dto.request.RoomCreateRequest;
 import com.roommate.domain.room.dto.request.RoomStatusUpdateRequest;
 import com.roommate.domain.room.dto.request.RoomUpdateRequest;
+import com.roommate.domain.room.dto.response.MyRoomListItemResponse;
 import com.roommate.domain.room.dto.response.RoomDetailResponse;
 import com.roommate.domain.room.dto.response.RoomMapItemResponse;
 import com.roommate.domain.room.entity.RoomDetailEntity;
 import com.roommate.domain.room.entity.RoomEntity;
 import com.roommate.domain.room.entity.RoomMapItemEntity;
 import com.roommate.domain.room.entity.RoomStatusEnum;
-import com.roommate.domain.room.repository.RoomImageRepository;
 import com.roommate.domain.room.repository.RoomRepository;
 import com.roommate.external.kakao.dto.KakaoGeoPoint;
 import com.roommate.external.kakao.service.KakaoMapService;
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriUtils;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -37,34 +36,10 @@ public class RoomServiceImpl implements RoomService {
     private static final String KAKAO_MAP_BASE = "https://map.kakao.com/link";
 
     private final RoomRepository roomRepository;
-    private final RoomImageRepository roomImageRepository;
     private final KakaoMapService kakaoMapService;
     private final FavoriteRepository favoriteRepository;
-    /**
-     * 방 이미지 전체 교체
-     * - 기존 이미지 모두 삭제
-     * - 새 URL 리스트를 순서대로 insert
-     * <p>
-     * 왜 이렇게 했는지:
-     * - "이미지 교체"는 단순 SQL 한 번이 아니라
-     * delete + 반복 insert가 필요한 비즈니스 로직이라
-     * Repository가 아니라 Service에서 책임지도록 함.
-     * - @Transactional 안에서 동작하므로 중간에 오류 나면 전체 롤백 가능.
-     */
-    private void replaceRoomImages(Long roomId, List<String> imageUrls) {
-        // 1) 기존 이미지 전체 삭제
-        roomImageRepository.deleteByRoomId(roomId);
+    private final RoomImageService roomImageService;
 
-        // 2) 새 이미지가 없으면 그대로 종료
-        if (imageUrls == null || imageUrls.isEmpty()) {
-            return;
-        }
-
-        // 3) 새 이미지 순서대로 저장 (0부터 sort_order 부여)
-        for (int i = 0; i < imageUrls.size(); i++) {
-            roomImageRepository.insertRoomImage(roomId, imageUrls.get(i), i);
-        }
-    }
 
     /**
      * 공통: 방 조회 + 소유자(memberId) 검증
@@ -95,12 +70,8 @@ public class RoomServiceImpl implements RoomService {
      * - createRoom 내부 if/else 로직을 메서드로 캡슐화해서
      * "좌표 보완" 이라는 의도가 더 잘 보이게 함.
      */
-    private KakaoGeoPoint resolveGeoPoint(Double lat, Double lng, String address) {
-        if (lat != null && lng != null) {
-            return new KakaoGeoPoint(lat, lng);
-        }
-
-        if (address == null) {
+    private KakaoGeoPoint resolveGeoPoint(String address) {
+        if (address == null || address.isBlank()) {
             throw new ApiException(ErrorCode.INVALID_ROOM_LOCATION);
         }
 
@@ -147,6 +118,7 @@ public class RoomServiceImpl implements RoomService {
      * - 필드가 추가/변경되더라도 한 곳만 수정하면 됨.
      */
     private void applyUpdate(RoomEntity roomEntity, RoomUpdateRequest request) {
+        KakaoGeoPoint point = resolveGeoPoint(request.getAddress());
         roomEntity.setRoomTitle(request.getTitle());
         roomEntity.setRoomContent(request.getContent());
         roomEntity.setRoomTypeId(request.getRoomTypeId());
@@ -157,8 +129,8 @@ public class RoomServiceImpl implements RoomService {
         roomEntity.setAddress(request.getAddress());
         roomEntity.setLegalDong(request.getLegalDong());
         roomEntity.setLandNumber(request.getLandNumber());
-        roomEntity.setLat(request.getLat());
-        roomEntity.setLng(request.getLng());
+        roomEntity.setLat(point.getLat());
+        roomEntity.setLng(point.getLng());
         roomEntity.setAvailableFrom(request.getAvailableFrom());
         roomEntity.setMaxRoommates(request.getMaxRoommates());
     }
@@ -180,25 +152,13 @@ public class RoomServiceImpl implements RoomService {
     @Override
     @Transactional
     public Long createRoom(RoomCreateRequest roomCreateRequest, Long memberId) {
-        // 🔍 1차 검증: 클라이언트에서 들어온 값 상태 확인
-        log.info("[RoomService] createRoom address raw = {}", roomCreateRequest.getAddress());
-        log.info("[RoomService] createRoom lat = {}, lng = {}", roomCreateRequest.getLat(), roomCreateRequest.getLng());
 
-        // 1) 좌표 결정 (프론트에서 주면 그대로, 없고 address 있으면 Kakao로 보완)
-        KakaoGeoPoint point = resolveGeoPoint(
-                roomCreateRequest.getLat(),
-                roomCreateRequest.getLng(),
-                roomCreateRequest.getAddress()
-        );
-
-        // 2) DTO -> Entity 변환
-        // 왜: DTO -> Entity 변환을 Service에서 수행해서 Controller는 얇게 유지
+        KakaoGeoPoint point = resolveGeoPoint(roomCreateRequest.getAddress());
         RoomEntity roomEntity = toRoomEntity(roomCreateRequest, memberId, point);
 
         roomRepository.insertRoom(roomEntity);
 
-        // 이미지 저장 (있다면)
-        replaceRoomImages(roomEntity.getRoomId(), roomCreateRequest.getImageUrls());
+        roomImageService.attachTempImagesToRoom(roomEntity.getRoomId(), memberId, roomCreateRequest.getTempFileIds());
 
         return roomEntity.getRoomId();
     }
@@ -224,7 +184,7 @@ public class RoomServiceImpl implements RoomService {
         roomRepository.updateRoom(roomEntity);
 
         // 이미지 전체 교체 정책
-        replaceRoomImages(roomId, roomUpdateRequest.getImageUrls());
+        roomImageService.attachTempImagesToRoom(roomId, memberId, roomUpdateRequest.getTempFileIds());
     }
 
     @Override
@@ -249,7 +209,7 @@ public class RoomServiceImpl implements RoomService {
         List<String> ownerTags = memberService.getMemberTags(ownerId);
 
         // 이미지 리스트 추가
-        List<String> imageUrls = roomImageRepository.findImageUrlsByRoomId(roomId);
+        List<String> imageUrls = roomImageService.findImageUrlsByRoomId(roomId);
 
         String kakaoMapUrl = null;
         String kakaoDirectionUrl = null;
@@ -295,7 +255,7 @@ public class RoomServiceImpl implements RoomService {
                 roomDetailEntity.getRoomCreatedAt(),
                 roomDetailEntity.getRoomUpdatedAt(),
                 roomDetailEntity.getOwnerId(),
-                roomDetailEntity.getOwnerNickname(),
+                roomDetailEntity.getOwnerName(),
                 roomDetailEntity.getOwnerPhotoUrl(),
                 ownerTags,
                 imageUrls,
@@ -329,4 +289,9 @@ public class RoomServiceImpl implements RoomService {
                         roomMapItemEntity.getThumbnailUrl())).toList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyRoomListItemResponse> getMyRooms(Long memberId) {
+        return roomRepository.findMyRooms(memberId);
+    }
 }

--- a/src/main/java/com/roommate/domain/room/service/RoomTypeService.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomTypeService.java
@@ -1,0 +1,11 @@
+package com.roommate.domain.room.service;
+
+import com.roommate.domain.room.dto.response.RoomTypeResponse;
+
+import java.util.List;
+
+public interface RoomTypeService {
+
+    public List<RoomTypeResponse> getRoomTypes();
+
+}

--- a/src/main/java/com/roommate/domain/room/service/RoomTypeServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomTypeServiceImpl.java
@@ -1,0 +1,21 @@
+package com.roommate.domain.room.service;
+
+import com.roommate.domain.room.dto.response.RoomTypeResponse;
+import com.roommate.domain.room.repository.RoomTypeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoomTypeServiceImpl implements RoomTypeService{
+    private final RoomTypeRepository roomTypeRepository;
+
+    @Override
+    public List<RoomTypeResponse> getRoomTypes() {
+        return roomTypeRepository.findAll().stream().map(rt -> new RoomTypeResponse(rt.getRoomTypeId(),rt.getRoomTypeName())).toList();
+    }
+}

--- a/src/main/resources/mapper/file/TempUploadFile.xml
+++ b/src/main/resources/mapper/file/TempUploadFile.xml
@@ -6,6 +6,8 @@
 <mapper namespace="com.roommate.domain.file.repository.TempUploadFileRepository">
     <resultMap id="fileMap" type="com.roommate.domain.file.entity.TempUploadFileEntity">
         <id property="tempFileId" column="temp_file_id"/>
+        <result property="memberId" column="member_id"/>
+        <result property="signupKey" column="signup_key"/>
         <result property="originalName" column="original_name"/>
         <result property="tempPath" column="temp_path"/>
         <result property="used" column="used"/>
@@ -18,6 +20,20 @@
         WHERE temp_file_id = #{tempFileId}
     </select>
 
+    <select id="findByIdAndMemberId" resultMap="fileMap">
+        SELECT *
+        FROM temp_upload_files
+        WHERE temp_file_id = #{tempFileId}
+        AND member_id = #{memberId}
+    </select>
+
+    <select id="findByIdAndSignupKey" resultMap="fileMap">
+        SELECT *
+        FROM temp_upload_files
+        WHERE temp_file_id = #{tempFileId}
+        AND signup_key = #{signupKey}
+    </select>
+
     <select id="findExpired" resultMap="fileMap">
         SELECT *
         FROM temp_upload_files
@@ -26,17 +42,22 @@
 
     <insert id="save" useGeneratedKeys="true" keyProperty="tempFileId"
             parameterType="com.roommate.domain.file.entity.TempUploadFileEntity">
-        INSERT INTO temp_upload_files ( original_name , temp_path , used )
-        VALUES ( #{originalName} , #{tempPath} , #{used} )
+        INSERT INTO temp_upload_files (member_id , signup_key , original_name , temp_path , used )
+        VALUES (#{memberId} , #{signupKey} , #{originalName} , #{tempPath} , #{used} )
     </insert>
 
     <update id="updateUsed" parameterType="com.roommate.domain.file.entity.TempUploadFileEntity">
         UPDATE temp_upload_files
-        <set>
-            used = #{used},
-        </set>
+        SET used = #{used}
         WHERE
         temp_file_id = #{tempFileId}
+    </update>
+
+    <update id="updateUsedAndPath">
+        UPDATE temp_upload_files
+        SET used = #{used},
+        temp_path = #{tempPath}
+        WHERE temp_file_id = #{tempFileId}
     </update>
 
     <delete id="deleteById">

--- a/src/main/resources/mapper/member/Member.xml
+++ b/src/main/resources/mapper/member/Member.xml
@@ -107,4 +107,12 @@
         WHERE member_id = #{memberId}
         AND deleted = 0
     </update>
+
+    <update id="updatePhotoUrl">
+        UPDATE members
+        SET photo_url = #{photoUrl},
+        member_updated_at = NOW()
+        WHERE member_id = #{memberId}
+        AND deleted = 0
+    </update>
 </mapper>

--- a/src/main/resources/mapper/room/Room.xml
+++ b/src/main/resources/mapper/room/Room.xml
@@ -108,6 +108,28 @@
         AND r.lng BETWEEN #{west} AND #{east}
     </select>
 
+    <select id="findMyRooms" resultType="com.roommate.domain.room.dto.response.MyRoomListItemResponse">
+        SELECT
+        r.room_id        AS roomId,
+        r.room_title     AS title,
+        r.address        AS address,
+        r.monthly_rent   AS monthlyRent,
+        r.deposit        AS deposit,
+        r.status         AS status,
+        (
+        SELECT ri.image_url
+        FROM room_image ri
+        WHERE ri.room_id = r.room_id
+        ORDER BY ri.sort_order ASC, ri.image_id ASC
+        LIMIT 1
+        ) AS thumbnailUrl,
+        r.room_created_at AS roomCreatedAt
+        FROM rooms r
+        WHERE r.member_id = #{memberId}
+        AND r.deleted = 0
+        ORDER BY r.room_created_at DESC
+    </select>
+
     <!-- 상세 조회: 조인으로 한 번에 -->
     <select id="findDetailById" resultType="com.roommate.domain.room.entity.RoomDetailEntity">
         SELECT
@@ -132,7 +154,7 @@
         r.status        AS status,
         r.room_created_at AS roomCreatedAt,
         m.member_id     AS ownerId,
-        m.name          AS ownerNickname,
+        m.name          AS ownerName,
         m.photo_url     AS ownerPhotoUrl
         FROM rooms r
         JOIN members m ON r.member_id = m.member_id

--- a/src/main/resources/mapper/room_type/RoomType.xml
+++ b/src/main/resources/mapper/room_type/RoomType.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.roommate.domain.room.repository.RoomTypeRepository">
+
+    <resultMap id="roomTypeMap" type="com.roommate.domain.room.entity.RoomTypeEntity">
+        <id property="roomTypeId" column="room_type_id"/>
+        <result property="roomTypeName" column="room_type_name"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <select id="findAll" resultMap="roomTypeMap">
+        SELECT *
+        FROM room_types
+        ORDER BY room_type_id ASC
+    </select>
+
+    <select id="findById" resultMap="roomTypeMap">
+        SELECT *
+        FROM room_types
+        WHERE room_type_id = #{roomTypeId}
+    </select>
+    <insert id="insert" parameterType="com.roommate.domain.room.entity.RoomTypeEntity" useGeneratedKeys="true"
+            keyProperty="roomTypeId">
+        INSERT INTO room_types (
+        room_type_name
+        ) VALUES (
+        #{roomTypeName}
+        )
+    </insert>
+    <update id="update" parameterType="com.roommate.domain.room.entity.RoomTypeEntity">
+        UPDATE room_types
+        SET room_type_name = #{roomTypeName}
+        WHERE room_type_id = #{roomTypeId}
+    </update>
+    <delete id="delete">
+        DELETE
+        FROM room_types
+        WHERE room_type_id = #{roomTypeId}
+    </delete>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/auth/login.jsp
+++ b/src/main/webapp/WEB-INF/views/auth/login.jsp
@@ -33,6 +33,7 @@
           <img id="regProfilePhoto" src="" alt="프로필 사진" class="register-profile-photo">
           <input type="file" id="regPhotoFileInput" accept="image/*" style="display: none;"/>
           <input type="hidden" id="regProfileTempFileId" />
+          <input type="hidden" id="regSignupKey" />
           <button type="button" id="btnRegPhotoUpload" class="btn-regPhoto-upload">
             사진 추가
           </button>

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -19,6 +19,15 @@
 
   <!-- 오른쪽: 검색 / 알림 / 로그인/프로필 -->
   <div class="header-right">
+
+   <!-- ✅ 방 등록 버튼 (로그인일 때만 노출 권장) -->
+   <a href="${pageContext.request.contextPath}/rooms/roomCreate"
+      id="btnHeaderRoomCreate"
+      class="header-primary-btn"
+      style="display:none;">
+     + 방 등록
+   </a>
+
     <!-- 검색 아이콘 -->
     <button type="button" class="header-icon-btn" id="btnHeaderSearch">
       🔍

--- a/src/main/webapp/WEB-INF/views/members/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypage.jsp
@@ -44,7 +44,7 @@
       <div class="profile-summary-actions">
         <button type="button"
                 class="btn btn-dark"
-                onclick="location.href='${contextPath}/members/mypage/edit'">
+                onclick="location.href='${pageContext.request.contextPath}/members/mypage/edit'">
           프로필 수정
         </button>
       </div>
@@ -105,7 +105,18 @@
  </section>
 
   <section class="mypage-tab-content" id="tab-posts" style="display:none;">
-    <!-- TODO: 내 게시글 내용 -->
+      <div class="mypage-posts-head">
+        <h3 class="mypage-posts-title">내 게시글</h3>
+
+        <a class="btn-post-create"
+           href="${pageContext.request.contextPath}/rooms/roomCreate">
+          + 새 게시글 작성
+        </a>
+      </div>
+
+      <div id="myRoomList" class="my-room-list">
+        <p class="favorite-empty">내가 등록한 방이 없습니다.</p>
+      </div>
   </section>
 
   <section class="mypage-tab-content" id="tab-activities" style="display:none;">

--- a/src/main/webapp/WEB-INF/views/rooms/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/detail.jsp
@@ -1,15 +1,12 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>룸 상세 | 룸메이트</title>
 
-    <!-- 공통 스타일 (이미 사용 중이면 유지) -->
-    <link rel="stylesheet" href="<c:url value='/resources/css/login.css'/>">
     <!-- 상세 페이지 전용 스타일 -->
-    <link rel="stylesheet" href="<c:url value='/resources/css/room/room-detail.css'/>">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/room/room-detail.css"/>
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/common/header.jsp"/>
@@ -213,8 +210,6 @@
         </aside>
     </div>
 </div>
-
-<script type="module" src="${pageContext.request.contextPath}/resources/js/common/apiClient.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomDetail.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 

--- a/src/main/webapp/WEB-INF/views/rooms/map.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/map.jsp
@@ -1,5 +1,4 @@
 <%@ page contentType="text/html; charset=UTF-8" language="java" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -7,7 +6,7 @@
     <title>지도에서 찾기 | 룸메이트</title>
 
     <!-- 분리된 CSS -->
-    <link rel="stylesheet" href="<c:url value='/resources/css/room/room.css'/>">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/room/room.css"/>
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/common/header.jsp"/>

--- a/src/main/webapp/WEB-INF/views/rooms/roomCreate.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/roomCreate.jsp
@@ -1,0 +1,134 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8"/>
+  <title>방 등록 | 룸메이트</title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/room/room-create.css"/>
+</head>
+<body>
+<jsp:include page="/WEB-INF/views/common/header.jsp"/>
+
+<main class="room-create-main">
+  <div class="page-top">
+    <button type="button" id="btn-back" class="btn-link">← 마이페이지로</button>
+  </div>
+
+  <h1 class="page-title">방 등록하기</h1>
+  <p class="page-subtitle">룸메이트를 찾기 위한 방 정보를 등록해주세요</p>
+
+  <form id="roomCreateForm" class="form" novalidate>
+    <section class="card">
+      <div class="card-head">
+        <h2 class="card-title">기본 정보</h2>
+        <p class="card-desc">방의 기본 정보를 입력해주세요</p>
+      </div>
+
+      <div class="field">
+        <label class="label">제목 <span class="req">*</span></label>
+        <input id="title" class="input" type="text" placeholder="예: 강남역 도보 5분, 투룸 룸메이트 구함"/>
+      </div>
+
+      <div class="field">
+        <label class="label">상세 설명 <span class="req">*</span></label>
+        <textarea id="content" class="textarea" rows="4" placeholder="방/생활 환경을 자세히 적어주세요"></textarea>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 class="card-title">위치 정보</h2>
+        <p class="card-desc">주소 검색으로 선택하면 서버에서 좌표를 자동으로 계산해 저장합니다</p>
+      </div>
+
+      <div class="field">
+        <label class="label">주소 <span class="req">*</span></label>
+        <div class="addr-row">
+          <input id="address" class="input" type="text" placeholder="주소 검색을 눌러주세요" readonly/>
+          <button type="button" id="btnAddrSearch" class="btn btn-primary">주소 검색</button>
+        </div>
+        <label class="label" style="margin-top:10px;">상세주소(선택)</label>
+        <input id="addressDetail" class="input" type="text" placeholder="상세주소(선택) 예) 101동 1004호" />
+        <!-- 서버로 같이 보낼 값들(선택) -->
+        <input type="hidden" id="legalDong"/>
+        <input type="hidden" id="landNumber"/>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 class="card-title">방 정보</h2>
+        <p class="card-desc">금액/면적은 0 이상</p>
+      </div>
+
+      <div class="grid-2">
+        <div class="field">
+          <label class="label">월세 <span class="req">*</span></label>
+          <input id="monthlyRent" class="input" type="number" min="0" step="1" placeholder="500000"/>
+          <p class="help">현재 상세페이지가 /10000 해서 만원으로 보여주니, DB 저장 단위(원/만원)를 프로젝트 기준으로 통일하세요.</p>
+        </div>
+        <div class="field">
+          <label class="label">보증금 <span class="req">*</span></label>
+          <input id="deposit" class="input" type="number" min="0" step="1" placeholder="10000000"/>
+        </div>
+      </div>
+
+      <div class="grid-3">
+        <div class="field">
+          <label class="label">면적(m²) <span class="req">*</span></label>
+          <input id="areaM2" class="input" type="number" min="0" step="0.1" placeholder="25.0"/>
+        </div>
+        <div class="field">
+          <label class="label">층수</label>
+          <input id="floor" class="input" type="number" min="0" step="1" placeholder="3"/>
+        </div>
+        <div class="field">
+          <label class="label">최대 룸메이트</label>
+          <input id="maxRoommates" class="input" type="number" min="0" step="1" placeholder="2"/>
+        </div>
+      </div>
+
+      <div class="grid-2">
+        <div class="field">
+          <label class="label">방 타입 <span class="req">*</span></label>
+          <select id="roomTypeId" class="select">
+            <option value="">선택</option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label class="label">입주 가능일</label>
+          <input id="availableFrom" class="input" type="date"/>
+          <p class="help">미입력 시 협의 가능</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-head">
+        <h2 class="card-title">이미지 (MVP: 미리보기만)</h2>
+        <p class="card-desc">업로드 API 연결 시 imageUrls로 전송</p>
+      </div>
+
+      <div class="upload-wrap">
+        <label class="upload-box" for="photoInput">
+          <div class="upload-icon">⬆️</div>
+          <div class="upload-text">이미지 추가</div>
+          <input id="photoInput" type="file" accept="image/*" multiple hidden/>
+        </label>
+        <div class="preview-grid" id="previewGrid"></div>
+      </div>
+    </section>
+
+    <div class="bottom-actions">
+      <button type="button" id="btnCancel" class="btn btn-ghost">취소</button>
+      <button type="submit" class="btn btn-primary">방 등록하기</button>
+    </div>
+  </form>
+</main>
+
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomCreate.js"></script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
+</body>
+</html>

--- a/src/main/webapp/resources/css/common/header.css
+++ b/src/main/webapp/resources/css/common/header.css
@@ -82,3 +82,16 @@
   text-decoration: none;
   color: #111;
 }
+.header-primary-btn{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:10px 14px;
+  border-radius:10px;
+  font-weight:700;
+  background:#0b0f1a;
+  color:#fff;
+  text-decoration:none;
+  margin-right:10px;
+}
+.header-primary-btn:hover{ opacity:.9; }

--- a/src/main/webapp/resources/css/member/mypage-view.css
+++ b/src/main/webapp/resources/css/member/mypage-view.css
@@ -361,41 +361,224 @@
   font-size: 13px;
   margin-top: 4px;
 }
-.favorite-list {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+/* ===== 관심 방 카드(내 게시글 카드 톤으로) ===== */
+.favorite-list{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
 }
 
-.favorite-card {
-  display: flex;
-  gap: 16px;
-  background: #fff;
-  padding: 16px;
-  border-radius: 12px;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
-  transition: transform .1s;
+.favorite-card{
+  position:relative;
+  display:flex;
+  gap:18px;
+  padding:18px;
+  border:1px solid #eee;
+  border-radius:18px;
+  background:#fff;
+  box-shadow:0 6px 20px rgba(0,0,0,0.05);
+  cursor:pointer;
 }
 
-favorite-card:hover {
-  transform: translateY(-3px);
+.favorite-thumb{
+  width:140px;
+  height:100px;
+  border-radius:14px;
+  object-fit:cover;
+  background:#f3f4f6;
+  flex:0 0 140px;
 }
 
-.favorite-thumb img {
-  width: 120px;
-  height: 90px;
-  border-radius: 8px;
-  object-fit: cover;
+.favorite-body{
+  flex:1;
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
 }
 
-.favorite-info .favorite-title {
-  font-size: 16px;
-  font-weight: 700;
+.favorite-title{
+  margin:0;
+  font-size:18px;
+  font-weight:900;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
-.favorite-empty {
-  padding: 20px;
-  text-align: center;
-  color: #aaa;
+.favorite-price{
+  margin:0;
+  font-size:15px;
+  font-weight:800;
+  color:#111827;
+}
+
+.favorite-status{
+  display:inline-flex;
+  align-items:center;
+  width:fit-content;
+  padding:7px 12px;
+  border-radius:999px;
+  font-size:13px;
+  font-weight:900;
+  background:#0b0f1a;
+  color:#fff;
+}
+.favorite-status.RESERVED{ background:#0f766e; }
+.favorite-status.CLOSED{ background:#6b7280; }
+.favorite-status.HIDDEN{ background:#ef4444; }
+
+/* 모바일 */
+@media (max-width: 720px){
+  .favorite-card{ flex-direction:column; }
+  .favorite-thumb{ width:100%; height:180px; flex:auto; }
+}
+
+/* ===== 내 게시글 헤더(레퍼런스처럼 오른쪽 버튼) ===== */
+.mypage-posts-head{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  margin: 16px 0 14px;
+}
+.mypage-posts-title{
+  margin:0;
+  font-size:22px;
+  font-weight:800;
+}
+
+.btn-post-create{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  padding:12px 18px;
+  border-radius:14px;
+  background:#0b0f1a;
+  color:#fff;
+  text-decoration:none;
+  font-weight:800;
+  border: none;
+}
+.btn-post-create:hover{ opacity:.92; }
+
+/* ===== 내 게시글 카드(레퍼런스 형태) ===== */
+.my-room-list{
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+
+.my-post-card{
+  position:relative;
+  display:flex;
+  gap:18px;
+  padding:18px;
+  border:1px solid #eee;
+  border-radius:18px;
+  background:#fff;
+  box-shadow:0 6px 20px rgba(0,0,0,0.05);
+}
+
+.my-post-thumb{
+  width:140px;
+  height:100px;
+  border-radius:14px;
+  object-fit:cover;
+  background:#f3f4f6;
+  flex:0 0 140px;
+}
+
+.my-post-body{
+  flex:1;
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+
+.my-post-title{
+  margin:0;
+  font-size:18px;
+  font-weight:900;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.my-post-sub{
+  margin:0;
+  font-size:14px;
+  color:#6b7280;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.my-post-price{
+  margin:0;
+  font-size:15px;
+  font-weight:800;
+}
+
+/* 카드 오른쪽 위 상태 배지 */
+.my-post-status{
+  position:absolute;
+  top:16px;
+  right:16px;
+  padding:7px 12px;
+  border-radius:999px;
+  font-size:13px;
+  font-weight:900;
+  color:#fff;
+}
+
+/* 상태별 컬러 */
+.my-post-status.OPEN     { background:#111827; } /* 검정 */
+.my-post-status.RESERVED { background:#0f766e; } /* 청록/초록 */
+.my-post-status.CLOSED   { background:#6b7280; } /* 회색 */
+.my-post-status.HIDDEN   { background:#ef4444; } /* 빨강(비공개 강조) */
+
+/* 카드 오른쪽 아래 버튼들 */
+.my-post-actions{
+  position:absolute;
+  right:16px;
+  bottom:16px;
+  display:flex;
+  gap:10px;
+  align-items:center;
+}
+
+.my-post-btn{
+  padding:10px 14px;
+  border-radius:12px;
+  border:1px solid #e5e7eb;
+  background:#fff;
+  font-weight:800;
+  cursor:pointer;
+}
+.my-post-btn:hover{ background:#f9fafb; }
+
+.my-post-btn-danger{
+  border:none;
+  background:none;
+  color:#ef4444;
+  font-weight:900;
+  cursor:pointer;
+}
+.my-post-btn-danger:hover{ opacity:.85; }
+
+/* 작성일 */
+.my-post-date{
+  margin-top:10px;
+  font-size:13px;
+  color:#9ca3af;
+}
+
+/* (선택) 모바일 대응 */
+@media (max-width: 720px){
+  .my-post-card{ flex-direction:column; }
+  .my-post-thumb{ width:100%; height:180px; flex:auto; }
+  .my-post-actions{ position:static; justify-content:flex-end; margin-top:10px; }
+  .my-post-status{ top:14px; right:14px; }
 }

--- a/src/main/webapp/resources/css/room/room-create.css
+++ b/src/main/webapp/resources/css/room/room-create.css
@@ -1,0 +1,269 @@
+/* /resources/css/room/room-create.css */
+.room-create-main{
+  max-width: 1060px;
+  margin: 28px auto 60px;
+  padding: 0 16px;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color:#111827;
+}
+
+.page-top{
+  margin-bottom: 8px;
+}
+.back-link{
+  text-decoration:none;
+  color:#111827;
+  font-weight:600;
+}
+.page-title{
+  font-size: 34px;
+  margin: 12px 0 6px;
+}
+.page-subtitle{
+  color:#6b7280;
+  margin: 0 0 18px;
+}
+
+.card{
+  background:#fff;
+  border:1px solid #eef2f7;
+  border-radius:18px;
+  padding: 22px 24px;
+  box-shadow: 0 8px 24px rgba(15,23,42,0.04);
+  margin-bottom: 18px;
+}
+
+.card-head{
+  margin-bottom: 16px;
+}
+.card-title{
+  margin:0;
+  font-size:18px;
+  font-weight:800;
+}
+.card-desc{
+  margin:6px 0 0;
+  font-size:14px;
+  color:#6b7280;
+}
+
+.field{
+  margin-top: 14px;
+}
+.label{
+  display:block;
+  font-size:14px;
+  font-weight:700;
+  margin-bottom: 8px;
+}
+.req{ color:#ef4444; }
+
+.input, .textarea, .select{
+  width:100%;
+  box-sizing:border-box;
+  border: none;
+  outline:none;
+  background:#f3f4f6;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size:14px;
+  color:#111827;
+}
+
+.textarea{
+  resize: vertical;
+  min-height: 110px;
+}
+
+.help{
+  margin: 8px 0 0;
+  color:#9ca3af;
+  font-size:12.5px;
+}
+
+.input-icon{
+  position:relative;
+}
+.input-icon .icon{
+  position:absolute;
+  left:12px;
+  top:50%;
+  transform: translateY(-50%);
+  opacity:.7;
+}
+.input-icon .input{
+  padding-left: 38px;
+}
+
+.grid-2{
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 14px;
+}
+.grid-3{
+  display:grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 14px;
+  margin-top: 14px;
+}
+/* 주소 검색 줄 (input + 버튼) */
+.addr-row{
+  display:flex;
+  gap:10px;
+  align-items:stretch;
+}
+
+.addr-row .input{
+  flex:1;
+}
+
+/* 주소 검색 버튼은 폼의 submit 버튼 스타일과 분리 */
+#btnAddrSearch{
+  flex: 0 0 auto;
+  padding: 12px 14px;
+  border-radius: 12px;
+  font-weight: 800;
+  font-size: 14px;
+  white-space: nowrap;
+  cursor: pointer;
+  background: #111827;
+  color: #fff;
+  border: none;
+}
+
+#btnAddrSearch:hover{
+  opacity: .92;
+}
+/* 주소 input은 readonly라서 클릭 유도 */
+#address[readonly]{
+  cursor: pointer;
+  background: #f3f4f6;
+}
+#address[readonly]:hover{
+  background: #eef2ff;
+}
+#addressDetail{
+  margin-top: 10px;
+}
+
+/* 칩 */
+.chip-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin-top: 8px;
+}
+.chip{
+  border:1px solid #e5e7eb;
+  background:#fff;
+  padding: 8px 12px;
+  border-radius:999px;
+  font-size:13px;
+  cursor:pointer;
+}
+.chip.active{
+  border-color:#111827;
+  background:#111827;
+  color:#fff;
+}
+
+/* 업로드 */
+.upload-wrap{
+  display:flex;
+  gap: 16px;
+  align-items:flex-start;
+  margin-top: 10px;
+}
+.upload-box{
+  width: 280px;
+  height: 240px;
+  border: 2px dashed #e5e7eb;
+  border-radius: 16px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  background:#fff;
+}
+.upload-icon{
+  font-size: 28px;
+  opacity:.6;
+}
+.upload-text{
+  margin-top: 8px;
+  color:#6b7280;
+  font-weight:700;
+}
+
+.preview-grid{
+  flex:1;
+  display:grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+.preview-item{
+  position:relative;
+  width:100%;
+  padding-top: 70%;
+  border-radius: 14px;
+  overflow:hidden;
+  background:#f3f4f6;
+  border: 1px solid #eef2f7;
+}
+.preview-item img{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+}
+.preview-remove{
+  position:absolute;
+  top:8px;
+  right:8px;
+  border:none;
+  background: rgba(0,0,0,0.55);
+  color:#fff;
+  border-radius: 999px;
+  padding: 6px 10px;
+  cursor:pointer;
+  font-size:12px;
+}
+
+/* 하단 버튼 */
+.bottom-actions{
+  display:grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 22px;
+}
+.btn{
+  border:none;
+  border-radius: 14px;
+  padding: 14px 16px;
+  font-weight: 800;
+  cursor:pointer;
+  font-size: 14px;
+}
+.btn-ghost{
+  background:#fff;
+  border:1px solid #e5e7eb;
+  color:#111827;
+}
+.btn-primary{
+  background: linear-gradient(90deg, #0b1020, #070b17);
+  color:#fff;
+}
+.btn-primary:hover{
+  filter: brightness(1.05);
+}
+
+@media (max-width: 900px){
+  .grid-2, .grid-3{ grid-template-columns: 1fr; }
+  .upload-wrap{ flex-direction:column; }
+  .upload-box{ width:100%; height: 220px; }
+  .preview-grid{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .bottom-actions{ grid-template-columns: 1fr; }
+}

--- a/src/main/webapp/resources/js/auth/login.js
+++ b/src/main/webapp/resources/js/auth/login.js
@@ -4,37 +4,147 @@ import {
   saveTokens,
   clearTokens,
   getAccessToken,
-  getTokenType,
   getRefreshToken,
 } from "../common/authTokenStorage.js";
 import { apiRequest } from "../common/apiClient.js";
 
-  // 페이지 진입 시 accessToken 만료되어 있으면 refreshToken으로 자동 재발급 시도
-  async function syncAuthOnPageLoad() {
-    const accessToken = getAccessToken();
-    const refreshToken = getRefreshToken();
+// ===== signup photo draft (사진만 복구) =====
+const SIGNUP_KEY_KEY = "signupDraftKey";
+const SIGNUP_DRAFT_VERSION = "v1";
+const SIGNUP_PHOTO_TTL_MS = 24 * 60 * 60 * 1000;
+// 네 실제 DOM id들 (여기만 맞추면 나머지 안 건드려도 됨)
+const DOM = {
+  signupKeyInputId: "regSignupKey",
+  tempFileIdInputId: "regProfileTempFileId",
+  previewImgId: "regProfilePhoto",
+};
+function signupPhotoKey(signupKey) {
+  return `draft:auth:signupPhoto:${signupKey}:${SIGNUP_DRAFT_VERSION}`;
+}
 
-    // 둘 다 없으면 → 진짜 비로그인
-    if (!accessToken && !refreshToken) {
-      return;
-    }
+function getOrCreateSignupKey() {
+  let key = localStorage.getItem(SIGNUP_KEY_KEY);
+  if (!key) {
+    key = crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+    localStorage.setItem(SIGNUP_KEY_KEY, key);
+  }
+  return key;
+}
 
-    try {
-      // /api/members/me 를 apiRequest 로 호출
-      //  - accessToken 유효하면 그대로 200
-      //  - accessToken 만료면 401 → apiClient.js 가 /api/auth/refresh 호출 후 재요청
-      const res = await apiRequest("/api/members/me", { method: "GET" });
+function saveSignupPhotoDraft({ signupKey, tempFileId, tempUrl }) {
+  if (!signupKey || !tempFileId || !tempUrl) return;
+  const payload = {
+    signupKey,
+    tempFileId,
+    tempUrl,
+    savedAt: Date.now(),
+    ttlMs: SIGNUP_PHOTO_TTL_MS,
+    path: location.pathname,
+    v: SIGNUP_DRAFT_VERSION,
+  };
+  localStorage.setItem(signupPhotoKey(signupKey), JSON.stringify(payload));
+}
 
-      if (!res.ok) {
-        // refresh 도 실패한 상황 → 토큰 다 지우고 완전 비로그인 처리
-        clearTokens();
-      }
-    } catch (err) {
-      console.error("syncAuthOnPageLoad error:", err);
-      // 에러가 나도 꼬인 토큰은 정리
+function loadSignupPhotoDraft(signupKey) {
+  try {
+    if (!signupKey) return null;
+    const raw = localStorage.getItem(signupPhotoKey(signupKey));
+    if (!raw) return null;
+
+    const data = JSON.parse(raw);
+    if (!data?.signupKey || !data?.tempFileId || !data?.tempUrl) return null;
+
+    if (data.signupKey !== signupKey) return null;
+    if (data.v !== SIGNUP_DRAFT_VERSION) return null;
+    if (data.path && data.path !== location.pathname) return null;
+
+    const ttl = Number(data.ttlMs ?? 0);
+    const savedAt = Number(data.savedAt ?? 0);
+    if (!ttl || !savedAt) return null;
+    if (Date.now() - savedAt > ttl) return null;
+
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+function clearSignupPhotoDraft(signupKey) {
+  if (!signupKey) return;
+  localStorage.removeItem(signupPhotoKey(signupKey));
+}
+
+function clearSignupDraftAll() {
+  const signupKey = localStorage.getItem(SIGNUP_KEY_KEY);
+  if (signupKey) clearSignupPhotoDraft(signupKey);
+  localStorage.removeItem(SIGNUP_KEY_KEY);
+}
+
+// 페이지 진입 시 accessToken 만료되어 있으면 refreshToken으로 자동 재발급 시도
+async function syncAuthOnPageLoad() {
+  const accessToken = getAccessToken();
+  const refreshToken = getRefreshToken();
+
+  // 둘 다 없으면 → 진짜 비로그인
+  if (!accessToken && !refreshToken) {
+    return;
+  }
+
+  try {
+    // /api/members/me 를 apiRequest 로 호출
+    //  - accessToken 유효하면 그대로 200
+    //  - accessToken 만료면 401 → apiClient.js 가 /api/auth/refresh 호출 후 재요청
+    const res = await apiRequest("/api/members/me", { method: "GET" });
+
+    if (!res.ok) {
+      // refresh 도 실패한 상황 → 토큰 다 지우고 완전 비로그인 처리
       clearTokens();
     }
+  } catch (err) {
+    console.error("syncAuthOnPageLoad error:", err);
+    // 에러가 나도 꼬인 토큰은 정리
+    clearTokens();
   }
+}
+
+async function initSignupDraftPhotoUI() {
+  // signup_key는 "항상 유지" (회원가입 폼 열 때마다 동일)
+  const signupKey = getOrCreateSignupKey();
+  const signupKeyInput = document.getElementById(DOM.signupKeyInputId);
+  if (signupKeyInput) signupKeyInput.value = signupKey;
+
+  // 사진 드래프트가 있으면 "물어보고" 복구
+  const draft = loadSignupPhotoDraft(signupKey);
+  if (!draft) return;
+
+  const ok = confirm("이전에 업로드한 프로필 사진이 남아있습니다.\n불러오시겠습니까?");
+  if (!ok) {
+    try {
+      await fetch(`/api/files/temp/profile-signup?temp_file_id=${encodeURIComponent(draft.tempFileId)}&signup_key=${encodeURIComponent(draft.signupKey)}`, {
+        method: "DELETE",
+      });
+    } catch (e) {
+      console.error("temp delete failed:", e);
+    }
+    clearSignupPhotoDraft(signupKey);
+
+    const tempIdInput = document.getElementById(DOM.tempFileIdInputId);
+    if (tempIdInput) tempIdInput.value = "";
+
+    const preview = document.getElementById(DOM.previewImgId);
+    if (preview) preview.src = "";
+
+    return;
+  }
+  // 3) hidden tempFileId 복구
+  const tempIdInput = document.getElementById(DOM.tempFileIdInputId);
+  if (tempIdInput) tempIdInput.value = String(draft.tempFileId);
+
+  // 4) 미리보기 복구
+  const preview = document.getElementById(DOM.previewImgId);
+  if (preview) preview.src = draft.tempUrl;
+
+}
 
 document.addEventListener("DOMContentLoaded", async () => {
   // 1) 우선 accessToken 이 만료돼 있으면 여기서 refresh 시도
@@ -44,8 +154,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   setupLoginForm();
   setupRegisterForm();
   loadFormCodes();
+  // 업로드 기능은 항상 붙여두고,
+  // draft 복구(confirm)는 register 탭 열릴 때만 실행
   setupRegisterPhotoUpload();
 });
+
 
 
 /* =====================
@@ -69,6 +182,7 @@ function openAuthModal(defaultTab = "login") {
     registerTabBtn.classList.add("active");
     loginTab.classList.add("hidden");
     registerTab.classList.remove("hidden");
+    initSignupDraftPhotoUI();
   } else {
     // login
     loginTabBtn.classList.add("active");
@@ -109,6 +223,7 @@ function setupTabs() {
       } else {
         loginTab.classList.add("hidden");
         registerTab.classList.remove("hidden");
+        initSignupDraftPhotoUI();
       }
     });
   });
@@ -127,13 +242,13 @@ function setupLoginForm() {
 
   loginForm.addEventListener("submit", async (e) => {
     e.preventDefault();
-    loginError.textContent = "";
+    if (loginError) loginError.textContent = "";
 
-    const email = loginEmail.value.trim();
-    const password = loginPassword.value;
+    const email = loginEmail?.value?.trim() ?? "";
+    const password = loginPassword?.value ?? "";
 
     if (!email || !password) {
-      loginError.textContent = "이메일과 비밀번호를 입력해주세요.";
+      if (loginError) loginError.textContent = "이메일과 비밀번호를 입력해주세요.";
       return;
     }
 
@@ -172,15 +287,9 @@ function setupLoginForm() {
         return;
       }
 
-        saveTokens({
-          accessToken,
-          refreshToken,
-          tokenType: tokenType || "Bearer",
-        });
+        saveTokens({accessToken,refreshToken,tokenType: tokenType || "Bearer",});
 
       closeAuthModal();
-      // 로그인 후 원하는 곳으로 이동
-      // location.href = "/main";
       location.reload();
     } catch (err) {
       console.error("Login error:", err);
@@ -197,11 +306,10 @@ function setupRegisterPhotoUpload() {
   const uploadBtn = document.getElementById("btnRegPhotoUpload");
   const previewImg = document.getElementById("regProfilePhoto");
   const tempIdInput = document.getElementById("regProfileTempFileId");
+  const signupKeyInput = document.getElementById("regSignupKey");
 
   // 요소 중 하나라도 없으면 안전하게 종료
-  if (!fileInput || !uploadBtn || !previewImg) {
-    return;
-  }
+  if (!fileInput || !uploadBtn || !previewImg || !tempIdInput || !signupKeyInput) return;
 
   // 버튼 클릭 → 숨겨진 file input 클릭
   uploadBtn.addEventListener("click", () => {
@@ -220,11 +328,18 @@ function setupRegisterPhotoUpload() {
       return;
     }
 
+    const signupKey = signupKeyInput.value || getOrCreateSignupKey();
+    signupKeyInput.value = signupKey;
+    if (!signupKey) {
+      console.error("[SignupUpload] signupKey missing. Upload aborted.");
+      return;
+    }
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("signup_key", signupKey);
 
     try {
-      const res = await fetch("/api/files/temp/profile", {
+      const res = await fetch(`/api/files/temp/profile-signup`, {
         method: "PUT",
         body: formData,
       });
@@ -236,8 +351,8 @@ function setupRegisterPhotoUpload() {
 
       const data = await res.json();
       // 백엔드 TempUploadFileResponse: temp_file_id, temp_url
-      const tempFileId = data.temp_file_id;
-      const tempUrl    = data.temp_url;
+      const tempFileId = data.temp_file_id ?? data.tempFileId;
+      const tempUrl    = data.temp_url ?? data.tempPath ?? data.temp_path;
 
       // 1) hidden input에 temp_file_id 저장 → 회원가입 submit 때 같이 보냄
       tempIdInput.value = tempFileId;
@@ -245,9 +360,13 @@ function setupRegisterPhotoUpload() {
       // 2) 미리보기 이미지 변경
       previewImg.src = tempUrl;
 
+      // 3) 사진만 draft 저장 (정석)
+      saveSignupPhotoDraft({ signupKey, tempFileId, tempUrl });
     } catch (err) {
       console.error("temp profile upload error:", err);
       alert("이미지 업로드 중 오류가 발생했습니다.");
+    } finally {
+      fileInput.value = "";
     }
   });
 }
@@ -264,48 +383,47 @@ function setupRegisterForm() {
 async function handleRegisterSubmit(e) {
   e.preventDefault();
 
-  const name = document.getElementById("regName").value.trim();
-  const email = document.getElementById("regEmail").value.trim();
-  const phone = document.getElementById("regPhone").value.trim();
-  const password = document.getElementById("regPassword").value;
-  const confirm = document.getElementById("regConfirm").value;
-  const smoking = document.getElementById("regSmoking").value;       // NON_SMOKER | SMOKER
-  const drinking = document.getElementById("regDrinking").value;     // NONE | SOCIAL | OFTEN
-  const sleepTime = document.getElementById("regSleepTime").value || null;
-  const workTypeSelect = document.getElementById("regWorkType");
-  const workTypeRaw = workTypeSelect.value;
-  const mbti = document.getElementById("regMbti").value || null;
+  const name = document.getElementById("regName")?.value?.trim() ?? "";
+  const email = document.getElementById("regEmail")?.value?.trim() ?? "";
+  const phone = document.getElementById("regPhone")?.value?.trim() ?? "";
+  const password = document.getElementById("regPassword")?.value ?? "";
+  const confirmPw = document.getElementById("regConfirm")?.value ?? "";
+  const smoking = document.getElementById("regSmoking")?.value ?? "NON_SMOKER";
+  const drinking = document.getElementById("regDrinking")?.value ?? "NONE";
+  const sleepTime = document.getElementById("regSleepTime")?.value || null;
+  const workTypeRaw = document.getElementById("regWorkType")?.value ?? "";
+  const mbti = document.getElementById("regMbti")?.value || null;
 
   // 🔹 숨겨진 tempFileId
-  const profileTempFileIdVal = document.getElementById("regProfileTempFileId").value;
+  const profileTempFileIdVal = document.getElementById(DOM.tempFileIdInputId)?.value ?? "";
   const profileTempFileId = profileTempFileIdVal ? Number(profileTempFileIdVal) : null;
 
-  const registerError = document.getElementById("registerError");
-  registerError.textContent = "";
+  const signupKey = document.getElementById("regSignupKey")?.value || null;
 
-  if (password !== confirm) {
-    registerError.textContent = "비밀번호가 일치하지 않습니다.";
+  const registerError = document.getElementById("registerError");
+  if (registerError) registerError.textContent = "";
+
+  if (password !== confirmPw) {
+    if (registerError) {
+      registerError.textContent = "비밀번호가 일치하지 않습니다.";
+    }
     return;
   }
   // workTypeId 필수 체크 (DTO @NotNull)
   if (!workTypeRaw) {
+    if (registerError) {
     registerError.textContent = "직업/라이프스타일을 선택해주세요.";
+    }
     return;
   }
   const workTypeId = Number(workTypeRaw);
 
   // 체크된 취미/선호/반려동물 ID 수집
-  const hobbyIds = Array.from(
-    document.querySelectorAll(".hobby-checkbox:checked")
-  ).map((el) => Number(el.value));
+  const hobbyIds = Array.from(document.querySelectorAll(".hobby-checkbox:checked")).map((el) => Number(el.value));
 
-  const preferenceIds = Array.from(
-    document.querySelectorAll(".preference-checkbox:checked")
-  ).map((el) => Number(el.value));
+  const preferenceIds = Array.from(document.querySelectorAll(".preference-checkbox:checked")).map((el) => Number(el.value));
 
-  const petIds = Array.from(
-    document.querySelectorAll(".pet-checkbox:checked")
-  ).map((el) => Number(el.value));
+  const petIds = Array.from(document.querySelectorAll(".pet-checkbox:checked")).map((el) => Number(el.value));
 
   // 여기부터는 백엔드 SignUpRequest 필드 이름(camelCase)에 맞춘다
   const payload = {
@@ -329,9 +447,9 @@ async function handleRegisterSubmit(e) {
 
     // 🔹 임시 파일 ID 전달 (SignUpRequest.profileTempFileId)
     profile_temp_file_id: profileTempFileId,
+    signup_key: signupKey,
 
-    // 🔹 temp 파일을 쓰는 경우 photo_url은 null로
-    photo_url: profileTempFileId ? null : (photoUrl || null),
+    photo_url: null,
   };
 
   try {
@@ -349,12 +467,13 @@ async function handleRegisterSubmit(e) {
           message = errBody.message;
         }
       } catch (_) {}
-      registerError.textContent = message;
+      if (registerError) registerError.textContent = message;
       return;
     }
 
     alert("회원가입이 완료되었습니다. 로그인 해주세요.");
 
+    clearSignupDraftAll();
     // 탭을 로그인 쪽으로 이동
     const loginTabBtn = document.querySelector('.auth-tab[data-tab="login"]');
     if (loginTabBtn) loginTabBtn.click();

--- a/src/main/webapp/resources/js/common/draftStore.js
+++ b/src/main/webapp/resources/js/common/draftStore.js
@@ -1,0 +1,80 @@
+// /resources/js/common/draftStore.js
+import { getAccessToken } from "./authTokenStorage.js";
+
+/**
+ * 프론트 안전 Draft Store
+ * - 페이지/기능별 격리
+ * - 사용자별 격리(로그인/게스트)
+ * - meta 검증 + TTL로 오염/충돌 방지
+ */
+
+function getOrCreateGuestScope() {
+  // 게스트도 탭/브라우저마다 분리되도록 랜덤 id 저장
+  const k = "guest_scope_id";
+  let id = sessionStorage.getItem(k);
+  if (!id) {
+    id = `${Date.now()}_${Math.random().toString(16).slice(2)}`;
+    sessionStorage.setItem(k, id);
+  }
+  return `guest:${id}`;
+}
+
+export function makeUserScope() {
+  const token = getAccessToken();
+  if (token) return `user:${token.slice(0, 12)}`; // 토큰 prefix로 사용자 스코프 분리
+  return getOrCreateGuestScope();
+}
+
+export function makeDraftKey({ app = "myapp", page, userScope, version = "v1" }) {
+  // key 자체는 상수로 고정하지 않고 "조합"으로 만든다
+  return `draft:${app}:${page}:${userScope}:${version}`;
+}
+
+export function saveDraft({ key, page, userScope, version = "v1", ttlMs = 1000 * 60 * 60 * 24, data }) {
+  const payload = {
+    meta: {
+      page,
+      user_scope: userScope,
+      schema_version: version,
+      saved_at: Date.now(),
+      ttl_ms: ttlMs,
+      path: location.pathname,
+    },
+    data,
+  };
+  localStorage.setItem(key, JSON.stringify(payload));
+}
+
+export function loadDraft({ key, page, userScope, version = "v1" }) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    if (!parsed?.meta || !parsed?.data) return null;
+
+    const m = parsed.meta;
+
+    // 페이지/유저/버전 검증
+    if (m.page !== page) return null;
+    if (m.user_scope !== userScope) return null;
+    if (m.schema_version !== version) return null;
+
+    // path 검증 (다른 화면에서 저장된 거면 버림)
+    if (m.path !== location.pathname) return null;
+
+    // TTL 검증
+    const ttl = Number(m.ttl_ms ?? 0);
+    const savedAt = Number(m.saved_at ?? 0);
+    if (!ttl || !savedAt) return null;
+    if (Date.now() - savedAt > ttl) return null;
+
+    return parsed.data;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDraft(key) {
+  localStorage.removeItem(key);
+}

--- a/src/main/webapp/resources/js/common/header.js
+++ b/src/main/webapp/resources/js/common/header.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const btnLogout     = document.getElementById("btnLogout");
   const btnOpenLogin  = document.getElementById("btnOpenLogin");
   const btnOpenRegister = document.getElementById("btnOpenRegister");
+  const btnHeaderRoomCreate = document.getElementById("btnHeaderRoomCreate");
 
   // 로그인/회원가입 버튼 클릭 → 모달 열기
   if (btnOpenLogin) {
@@ -27,6 +28,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const token = getAccessToken();
   if (!token) {
     // 비로그인
+    if (btnHeaderRoomCreate) btnHeaderRoomCreate.style.display = "none";
     authButtons && (authButtons.style.display = "flex");
     profileArea && (profileArea.style.display = "none");
     return;
@@ -48,11 +50,13 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     authButtons && (authButtons.style.display = "none");
     profileArea && (profileArea.style.display = "flex");
+    if (btnHeaderRoomCreate) btnHeaderRoomCreate.style.display = "inline-flex";
   } catch (e) {
     // 토큰 이상 → 비로그인 처리
     clearTokens();
     authButtons && (authButtons.style.display = "flex");
     profileArea && (profileArea.style.display = "none");
+    if (btnHeaderRoomCreate) btnHeaderRoomCreate.style.display = "none";
   }
 
   if (btnLogout) {

--- a/src/main/webapp/resources/js/member/mypageView.js
+++ b/src/main/webapp/resources/js/member/mypageView.js
@@ -14,6 +14,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     await loadMyProfile();
     await loadMyFavorites();
+    await loadMyRooms();
+    bindMyRoomActions();
   } catch (e) {
     console.error("mypage view init error:", e);
   }
@@ -158,40 +160,36 @@ function renderFavoriteList(list) {
 
   list.forEach((room) => {
     const roomId = room.roomId ?? room.room_id;
-    const title = room.roomTitle ?? room.room_title ?? "제목 없음";
+    const title = room.title ?? room.roomTitle ?? room.room_title ?? "제목 없음";
+    const address = room.address ?? "";
     const deposit = room.deposit;
     const monthlyRent = room.monthlyRent ?? room.monthly_rent;
-    const thumbnail = room.thumbnailUrl ?? room.thumbnail_url;
-    const depositMan = deposit != null ? Math.round(deposit / 10000) : null;
-    const monthlyMan = monthlyRent != null ? Math.round(monthlyRent / 10000) : null;
-    const depositText = depositMan != null ? `${depositMan.toLocaleString()}만` : "-";
-    const monthlyText = monthlyMan != null ? `${monthlyMan.toLocaleString()}만` : "-";
+    const status = room.status ?? "OPEN";
+    const thumb = room.thumbnailUrl ?? room.thumbnail_url ?? "/resources/img/no-image.png";
 
-    const status = room.status;
-    let statusLabel = "";
-    if (status === "OPEN") statusLabel = "모집중";
-    else if (status === "RESERVED") statusLabel = "예약중";
-    else if (status === "CLOSED") statusLabel = "마감";
-    else if (status) statusLabel = status;
+    const statusText =
+      status === "OPEN" ? "모집중" :
+      status === "RESERVED" ? "예약중" :
+      status === "CLOSED" ? "마감" :
+      status === "HIDDEN" ? "비공개" : status;
 
-    const card = document.createElement("div");
-    card.className = "favorite-card";
+    const card = document.createElement("article");
+    card.className = "my-post-card favorite-card"; // ✅ 내 게시글 카드 스타일 그대로 재사용
+    card.dataset.roomId = roomId;
 
     card.innerHTML = `
-      <div class="favorite-thumb">
-        <img src="${thumbnail || '/resources/img/no-image.png'}" alt="thumbnail">
+      <img class="my-post-thumb" src="${thumb}" alt="thumbnail" />
+      <div class="my-post-body">
+        <h4 class="my-post-title">${title}</h4>
+        <p class="my-post-sub">${address}</p>
+        <p class="my-post-price">보증금 ${formatMoney(deposit)} / 월세 ${formatMoney(monthlyRent)}</p>
       </div>
-      <div class="favorite-info">
-        <h3 class="favorite-title">${title}</h3>
-        <p class="favorite-meta">
-          보증금 ${depositText} | 월세 ${monthlyText}
-        </p>
-        <span class="favorite-status">${statusLabel}</span>
-      </div>
+
+      <div class="my-post-status ${status}">${statusText}</div>
     `;
 
     card.addEventListener("click", () => {
-      window.location.href = "/rooms/" + roomId;
+      window.location.href = `/rooms/${roomId}`;
     });
 
     container.appendChild(card);
@@ -415,4 +413,261 @@ async function handlePasswordChange() {
       alert("서버 오류가 발생했습니다.");
     }
   }
+}
+
+/** ===== 내 게시글 로드 ===== */
+async function loadMyRooms() {
+  const wrap = document.getElementById("myRoomList");
+  if (!wrap) return;
+
+  try {
+    const res = await apiRequest("/api/rooms/me", { method: "GET" });
+    if (!res.ok) throw new Error("my rooms load fail: " + res.status);
+
+    const rooms = await res.json();
+
+    // 비어있으면 빈 상태 유지
+    if (!Array.isArray(rooms) || rooms.length === 0) {
+      wrap.innerHTML = `<p class="favorite-empty">내가 등록한 방이 없습니다.</p>`;
+      return;
+    }
+    wrap.innerHTML = rooms.map(renderMyRoomCard).join("");
+  } catch (e) {
+    console.error("[mypage] loadMyRooms error:", e);
+    wrap.innerHTML = `<p class="favorite-empty">내 게시글을 불러오지 못했습니다.</p>`;
+  }
+}
+
+function renderMyRoomCard(room) {
+  const roomId = room.roomId ?? room.room_id;
+  const title = room.title ?? "-";
+  const address = room.address ?? "-";
+  const status = room.status ?? "OPEN";
+  const thumb = room.thumbnailUrl ?? room.thumbnail_url ?? "/resources/img/room/default-room.jpg";
+
+  const monthlyRent = room.monthlyRent ?? room.monthly_rent;
+  const deposit = room.deposit;
+
+  const priceText =
+    (monthlyRent != null && deposit != null)
+      ? `월 ${formatMoney(monthlyRent)} / 보증금 ${formatMoney(deposit)}`
+      : "가격 정보 없음";
+
+  const createdAt = room.roomCreatedAt ?? room.room_created_at;
+  const toggleLabel = (status === "OPEN") ? "모집 마감" : "모집 재개";
+  const hiddenLabel = (status === "HIDDEN") ? "공개" : "비공개";
+  return `
+    <article class="my-post-card" data-room-id="${roomId}">
+      <img class="my-post-thumb" src="${thumb}" alt="방 이미지">
+
+      <div class="my-post-body">
+        <h4 class="my-post-title">${escapeHtml(title)}</h4>
+        <p class="my-post-sub">${escapeHtml(address)}</p>
+        <p class="my-post-price">${escapeHtml(priceText)}</p>
+        <div class="my-post-date">${createdAt ? formatDate(createdAt) : ""}</div>
+      </div>
+
+      <div class="my-post-status ${status}">${statusText(status)}</div>
+
+      <div class="my-post-actions">
+        <button class="my-post-btn" data-action="edit" data-id="${roomId}">수정</button>
+        <button class="my-post-btn" data-action="toggle" data-id="${roomId}">
+          ${toggleLabel}
+        </button>
+        <button class="my-post-btn" data-action="toggle-hidden" data-id="${roomId}">
+          ${hiddenLabel}
+        </button>
+        <button class="my-post-btn-danger" data-action="delete" data-id="${roomId}">삭제</button>
+      </div>
+    </article>
+  `;
+}
+
+/** ===== 이벤트 위임(삭제/수정/상태변경) ===== */
+function bindMyRoomActions() {
+  const wrap = document.getElementById("myRoomList");
+  if (!wrap) return;
+
+  wrap.addEventListener("click", async (e) => {
+    const btn = e.target.closest("button[data-action]");
+        if (btn) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const action = btn.dataset.action;
+        const roomId = btn.dataset.id;
+        if (!roomId) return;
+
+        if (action === "delete") {
+          const ok = confirm("게시글을 삭제하면 더 이상 노출되지 않습니다.\n정말 삭제하시겠습니까?");
+          if (!ok) return;
+
+          try {
+            btn.disabled = true;
+            const res = await apiRequest(`/api/rooms/${roomId}`, { method: "DELETE" });
+            if (!res.ok) throw new Error("delete fail: " + res.status);
+
+            // 화면에서 제거
+            const card = btn.closest(".my-post-card");
+            card?.remove();
+
+            // 다 지워졌으면 empty 표시
+            if (wrap.querySelectorAll(".my-post-card").length === 0) {
+              wrap.innerHTML = `<p class="favorite-empty">내가 등록한 방이 없습니다.</p>`;
+            }
+          } catch (err) {
+            console.error(err);
+            alert("삭제 중 오류가 발생했습니다.");
+          } finally {
+            btn.disabled = false;
+          }
+          return;
+        }
+
+        if (action === "edit") {
+          location.href = `/rooms/${roomId}/edit`;
+          return;
+        }
+
+        if (action === "toggle") {
+          const card = btn.closest(".my-post-card");
+          const statusEl = card?.querySelector(".my-post-status");
+          if (!statusEl) return;
+
+          const currentStatus =
+            statusEl.classList.contains("OPEN") ? "OPEN" :
+            statusEl.classList.contains("RESERVED") ? "RESERVED" :
+            statusEl.classList.contains("CLOSED") ? "CLOSED" :
+            "HIDDEN";
+          if (currentStatus === "RESERVED" || currentStatus === "HIDDEN") {
+            alert("현재 상태에서는 변경할 수 없습니다.");
+            return;
+          }
+          const nextStatus = currentStatus === "OPEN" ? "CLOSED" : "OPEN";
+
+          try {
+            btn.disabled = true;
+            const res = await apiRequest(`/api/rooms/${roomId}/status`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status: nextStatus }),
+            });
+            if (!res.ok) throw new Error("status update fail: " + res.status);
+
+            statusEl.className = `my-post-status ${nextStatus}`;
+            statusEl.textContent = statusText(nextStatus);
+            btn.textContent = nextStatus === "OPEN" ? "모집 마감" : "모집 재개";
+          } catch (err) {
+            console.error(err);
+            alert("상태 변경 중 오류가 발생했습니다.");
+          } finally {
+            btn.disabled = false;
+          }
+          return;
+        }
+        if (action === "toggle-hidden") {
+          const card = btn.closest(".my-post-card");
+          const statusEl = card?.querySelector(".my-post-status");
+          if (!statusEl) return;
+
+          const currentStatus =
+            statusEl.classList.contains("OPEN") ? "OPEN" :
+            statusEl.classList.contains("RESERVED") ? "RESERVED" :
+            statusEl.classList.contains("CLOSED") ? "CLOSED" :
+            "HIDDEN";
+
+          // HIDDEN 토글은 "HIDDEN <-> OPEN" 으로 단순화 (정책)
+          const nextStatus = (currentStatus === "HIDDEN") ? "OPEN" : "HIDDEN";
+
+          try {
+            btn.disabled = true;
+            const res = await apiRequest(`/api/rooms/${roomId}/status`, {
+              method: "PATCH",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status: nextStatus }),
+            });
+            if (!res.ok) throw new Error("hidden status update fail: " + res.status);
+
+            // 배지 갱신
+            statusEl.className = `my-post-status ${nextStatus}`;
+            statusEl.textContent = statusText(nextStatus);
+
+            // 버튼 라벨 갱신
+            btn.textContent = (nextStatus === "HIDDEN") ? "공개" : "비공개";
+
+            // 모집마감 버튼도 HIDDEN일 때는 비활성/문구 변경(선택)
+            const toggleBtn = card.querySelector('button[data-action="toggle"]');
+            if (toggleBtn) {
+              if (nextStatus === "HIDDEN") {
+                toggleBtn.disabled = true;
+                toggleBtn.textContent = "비공개 중";
+              } else {
+                toggleBtn.disabled = false;
+                // 공개로 돌아오면 기본은 OPEN이라고 했으니:
+                toggleBtn.textContent = "모집 마감";
+              }
+            }
+          } catch (err) {
+            console.error(err);
+            alert("비공개 상태 변경 중 오류가 발생했습니다.");
+          } finally {
+            btn.disabled = false;
+          }
+          return;
+        }
+        return;
+      }
+    const card = e.target.closest(".my-post-card");
+    if (!card) return;
+
+    const roomId = card.dataset.roomId;
+    if (!roomId) return;
+
+    window.location.href = `/rooms/${roomId}`;
+  });
+}
+
+/** ===== 유틸 ===== */
+function formatMoney(v) {
+  const n = Number(v);
+  if (Number.isNaN(n)) return "-";
+  return n.toLocaleString("ko-KR");
+}
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("ko-KR", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+function statusText(status) {
+  switch (status) {
+    case "OPEN": return "모집중";
+    case "RESERVED": return "예약중";
+    case "CLOSED": return "마감";
+    case "HIDDEN": return "비공개";
+    default: return "비공개";
+  }
+}
+
+function normalizeImageUrl(url) {
+  if (!url) return "/resources/img/room-default.png"; // 너네 기본 이미지 하나 만들어두면 좋음
+
+  // http/https면 그대로
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+
+  // "/uploads/..." 같은 절대경로면 그대로
+  if (url.startsWith("/")) return url;
+
+  // "uploads/..." 같은 상대경로면 앞에 / 붙이기
+  return "/" + url;
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }

--- a/src/main/webapp/resources/js/room/roomCreate.js
+++ b/src/main/webapp/resources/js/room/roomCreate.js
@@ -1,0 +1,490 @@
+// ES Module
+// /resources/js/room/roomCreate.js
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
+import { makeUserScope, makeDraftKey, saveDraft, loadDraft, clearDraft } from "../common/draftStore.js";
+
+let selectedFiles = [];
+
+// ===== DraftStore keys =====
+const USER_SCOPE = makeUserScope();
+const APP = "roommate";
+const PAGE = "roomCreate";
+const VERSION = "v1";
+const TTL_MS = 1000 * 60 * 60 * 24;
+
+const TEXT_PAGE = `${PAGE}:text`;
+const IMG_PAGE = `${PAGE}:images`;
+
+const TEXT_KEY = makeDraftKey({ app: APP, page: TEXT_PAGE, userScope: USER_SCOPE, version: VERSION });
+const IMG_KEY  = makeDraftKey({ app: APP, page: IMG_PAGE, userScope: USER_SCOPE, version: VERSION });
+
+// ===== utils =====
+function v(id) {
+  return (document.getElementById(id)?.value ?? "").trim();
+}
+function n(id) {
+  const x = v(id);
+  return x === "" ? null : Number(x);
+}
+function i(id) {
+  const x = v(id);
+  return x === "" ? null : parseInt(x, 10);
+}
+
+function validate(payload) {
+  if (!payload.title) return "제목은 필수입니다.";
+  if (!payload.content) return "상세 설명은 필수입니다.";
+  if (!payload.address) return "주소는 필수입니다.";
+  if (payload.room_type_id == null || Number.isNaN(payload.room_type_id)) return "방 타입은 필수입니다.";
+
+  const checks = [
+    ["월세", payload.monthly_rent],
+    ["보증금", payload.deposit],
+  ];
+  for (const [name, val] of checks) {
+    if (val == null || Number.isNaN(val)) return `${name} 값을 입력해주세요.`;
+    if (val < 0) return `${name} 값은 0 이상이어야 합니다.`;
+  }
+  if (payload.area_m2 != null && payload.area_m2 < 0) return "면적은 0 이상이어야 합니다.";
+  if (payload.floor != null && payload.floor < 0) return "층수는 0 이상이어야 합니다.";
+  if (payload.max_roommates != null && payload.max_roommates < 0) return "최대 룸메이트는 0 이상이어야 합니다.";
+  return null;
+}
+
+// ===== debounce =====
+function debounce(fn, wait = 250) {
+  let t = null;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), wait);
+  };
+}
+
+function buildTextDraft() {
+  // 주소 + 상세주소는 "분리 값"으로 저장(복구 UX 좋게)
+  return {
+    title: v("title"),
+    content: v("content"),
+
+    room_type_id: v("roomTypeId"),
+    monthly_rent: v("monthlyRent"),
+    deposit: v("deposit"),
+    area_m2: v("areaM2"),
+    floor: v("floor"),
+
+    address: v("address"),
+    address_detail: v("addressDetail"),
+    legal_dong: v("legalDong"),
+    land_number: v("landNumber"),
+    available_from: v("availableFrom"),
+    max_roommates: v("maxRoommates"),
+  };
+}
+
+function saveTextDraft() {
+  saveDraft({
+    key: TEXT_KEY,
+    page: TEXT_PAGE,
+    userScope: USER_SCOPE,
+    version: VERSION,
+    ttlMs: TTL_MS,
+    data: buildTextDraft(),
+  });
+}
+
+function loadTextDraft() {
+  const d = loadDraft({
+    key: TEXT_KEY,
+    page: TEXT_PAGE,
+    userScope: USER_SCOPE,
+    version: VERSION,
+  });
+  if (!d || typeof d !== "object") return null;
+
+  // 완전 빈 draft면 무시
+  const meaningful = Object.keys(d).some((k) => String(d[k] ?? "").trim() !== "");
+  return meaningful ? d : null;
+}
+
+function clearTextDraft() {
+  clearDraft(TEXT_KEY);
+}
+
+function applyTextDraft(draft) {
+  if (!draft) return;
+
+  const setVal = (id, val) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.value = (val ?? "");
+  };
+
+  setVal("title", draft.title);
+  setVal("content", draft.content);
+
+  setVal("roomTypeId", draft.room_type_id);
+  setVal("monthlyRent", draft.monthly_rent);
+  setVal("deposit", draft.deposit);
+  setVal("areaM2", draft.area_m2);
+  setVal("floor", draft.floor);
+
+  setVal("address", draft.address);
+  setVal("addressDetail", draft.address_detail);
+  setVal("legalDong", draft.legal_dong);
+  setVal("landNumber", draft.land_number);
+  setVal("availableFrom", draft.available_from);
+  setVal("maxRoommates", draft.max_roommates);
+}
+
+const saveTextDraftDebounced = debounce(saveTextDraft, 250);
+
+function setupDraftAutoSave() {
+  // 네 form DOM id 기준
+  const ids = [
+    "title",
+    "content",
+    "roomTypeId",
+    "monthlyRent",
+    "deposit",
+    "areaM2",
+    "floor",
+    "address",
+    "addressDetail",
+    "legalDong",
+    "landNumber",
+    "availableFrom",
+    "maxRoommates",
+  ];
+
+  ids.forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener("input", saveTextDraftDebounced);
+    el.addEventListener("change", saveTextDraftDebounced);
+  });
+}
+
+// ===== room types =====
+async function loadRoomTypes() {
+  const select = document.getElementById("roomTypeId");
+  if (!select) return;
+
+  try {
+    const res = await apiRequest("/api/room-types", { method: "GET" });
+    if (!res.ok) {
+      console.warn("[room-create] room types load fail:", res.status);
+      return;
+    }
+
+    const list = await res.json();
+    // 초기화(첫 option 유지)
+    select.querySelectorAll("option:not(:first-child)").forEach((o) => o.remove());
+
+    (Array.isArray(list) ? list : []).forEach((rt) => {
+      const id = rt.roomTypeId ?? rt.room_type_id;
+      const name = rt.roomTypeName ?? rt.room_type_name;
+      if (id==null) return;
+
+      const opt = document.createElement("option");
+      opt.value = id;
+      opt.textContent = name ?? `타입-${id}`;
+      select.appendChild(opt);
+    });
+  } catch (e) {
+    console.error("[room-create] loadRoomTypes error:", e);
+  }
+}
+
+function setupAddressSearch() {
+  const btn = document.getElementById("btnAddrSearch");
+  if (!btn) return;
+
+  btn.addEventListener("click", () => {
+    new daum.Postcode({
+      oncomplete: function (data) {
+        // 도로명/지번 중 있으면 우선 적용
+        const road = data.roadAddress || "";
+        const jibun = data.jibunAddress || "";
+        const addr = road || jibun;
+
+        document.getElementById("address").value = addr;
+
+        // 법정동(있을 때만)
+        document.getElementById("legalDong").value = data.bname || "";
+
+        // 지번은 데이터가 파편화되어 있어서 MVP면 비우고, 나중에 정교화 추천
+        document.getElementById("landNumber").value = "";
+
+        // 상세주소로 포커스 이동
+        document.getElementById("addressDetail")?.focus();
+
+        saveTextDraftDebounced();
+      },
+    }).open();
+  });
+}
+
+// ===== temp upload =====
+async function uploadTempRoomImage(file) {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await apiRequest("/api/files/temp/room", {
+    method: "PUT",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new Error("temp room upload failed");
+  }
+
+  const data = await res.json();
+  return {
+    temp_file_id: data.temp_file_id ?? data.tempFileId,
+    temp_url: data.temp_url ?? data.tempPath ?? data.temp_path,
+  };
+}
+
+// ===== storage/preview =====
+function persistSelectedFiles() {
+  saveDraft({
+    key: IMG_KEY,
+    page: IMG_PAGE,
+    userScope: USER_SCOPE,
+    version: VERSION,
+    ttlMs: TTL_MS,
+    data: selectedFiles,
+  });
+}
+
+function clearPersistedFiles() {
+  clearDraft(IMG_KEY);
+}
+
+function renderPreview(grid) {
+  grid.innerHTML = "";
+  selectedFiles.forEach((it, idx) => {
+    const div = document.createElement("div");
+    div.className = "preview-item";
+    div.innerHTML = `
+      <img src="${it.temp_url}" alt="preview">
+      <button type="button" class="preview-remove" data-idx="${idx}">삭제</button>
+    `;
+    grid.appendChild(div);
+  });
+  persistSelectedFiles();
+}
+
+function loadTempImages() {
+  const arr = loadDraft({
+    key: IMG_KEY,
+    page: IMG_PAGE,
+    userScope: USER_SCOPE,
+    version: VERSION,
+  });
+  return Array.isArray(arr) && arr.length > 0 ? arr : null;
+}
+
+function restoreDraftsWithPrompt(grid) {
+  const textDraft = loadTextDraft();
+  const imgDraft = loadTempImages();
+
+  if (!textDraft && !imgDraft) return;
+
+  const ok = confirm("이전에 작성하던 내용/사진이 남아있습니다.\n불러오시겠습니까?");
+  if (!ok) {
+    clearTextDraft();
+    clearPersistedFiles();
+    selectedFiles = [];
+    grid.innerHTML = "";
+    return;
+  }
+
+  if (textDraft) applyTextDraft(textDraft);
+  if (imgDraft) {
+    selectedFiles = imgDraft;
+    renderPreview(grid);
+  }
+}
+// ===== image preview =====
+function setupImagePreview() {
+  const input = document.getElementById("photoInput");
+  const grid = document.getElementById("previewGrid");
+  if (!input || !grid) return;
+
+  restoreDraftsWithPrompt(grid);
+
+  input.addEventListener("change", async () => {
+    const files = Array.from(input.files || []);
+    if (files.length === 0) return;
+
+    const remain = 10 - selectedFiles.length;
+    if (remain <= 0) {
+      alert("이미지는 최대 10장까지 업로드할 수 있습니다.");
+      input.value = "";
+      return;
+    }
+
+    const toUpload = files.slice(0, remain);
+    if (files.length > remain) {
+      alert(`이미지는 최대 10장까지 업로드할 수 있어요.\n${remain}장만 업로드합니다.`);
+    }
+
+    input.disabled = true;
+
+    try {
+      let failCount = 0;
+
+      for (const file of toUpload) {
+        if (!file.type.startsWith("image/")) {
+          failCount++;
+          continue;
+        }
+        try {
+            const uploaded = await uploadTempRoomImage(file);
+
+            if (!uploaded.temp_file_id || !uploaded.temp_url) {
+              failCount++;
+              continue;
+            }
+
+            selectedFiles.push(uploaded);
+            renderPreview(grid);
+        } catch (e) {
+          console.error(e);
+          failCount++;
+        }
+      }
+      if (failCount > 0) {
+        alert(`이미지 ${failCount}장 업로드에 실패했습니다.`);
+      }
+    } finally {
+      input.value="";
+      input.disabled = false;
+    }
+  });
+
+  grid.addEventListener("click", (e) => {
+    const btn = e.target.closest(".preview-remove");
+    if (!btn) return;
+
+    const idx = Number(btn.dataset.idx);
+    if (Number.isNaN(idx)) return;
+
+    selectedFiles.splice(idx, 1);
+    renderPreview(grid);
+  });
+}
+
+// ===== submit =====
+async function submitRoom(e) {
+  e.preventDefault();
+
+  const form = document.getElementById("roomCreateForm");
+  const submitBtn = form?.querySelector('button[type="submit"]');
+
+  if (submitBtn?.dataset.loading === "true") return;
+  if (submitBtn) {
+    submitBtn.dataset.loading = "true";
+    submitBtn.disabled = true;
+  }
+
+  // 주소 + 상세주소 합치기
+  const addr = v("address");
+  const addrDetail = v("addressDetail");
+  const fullAddress = addrDetail ? `${addr} ${addrDetail}` : addr;
+
+  const payload = {
+    title: v("title"),
+    content: v("content"),
+
+    room_type_id: n("roomTypeId"),
+    monthly_rent: n("monthlyRent"),
+    deposit: n("deposit"),
+    area_m2: n("areaM2"),
+    floor: i("floor"),
+
+    address: fullAddress,
+    legal_dong: v("legalDong") || null,
+    land_number: v("landNumber") || null,
+    available_from: v("availableFrom") || null,
+    max_roommates: i("maxRoommates"),
+
+    temp_file_ids: selectedFiles.map((x) => x.temp_file_id),
+  };
+
+  const msg = validate(payload);
+  if (msg) {
+    alert(msg);
+    if (submitBtn) {
+      submitBtn.dataset.loading = "false";
+      submitBtn.disabled = false;
+    }
+    return;
+  }
+
+  try {
+    const res = await apiRequest("/api/rooms", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      let m = "등록에 실패했습니다.";
+      try {
+        const err = await res.json();
+        m = err?.message || m;
+      } catch (_) {}
+      alert(m);
+      return;
+    }
+
+    const roomId = await res.json();
+    clearPersistedFiles();
+    clearTextDraft();
+    alert("등록이 완료되었습니다.");
+    window.location.href = "/rooms/" + roomId;
+  } catch (e) {
+    console.error("[room-create] submit error:", e);
+    alert("서버 오류가 발생했습니다.");
+  } finally {
+     if (submitBtn) {
+       submitBtn.dataset.loading = "false";
+       submitBtn.disabled = false;
+     }
+  }
+}
+
+// ===== init =====
+window.addEventListener("DOMContentLoaded", async () => {
+  const ok = requireLogin();
+  if (!ok) return;
+
+  document.getElementById("btn-back")?.addEventListener("click", () => {
+    if (history.length > 1) history.back();
+    else window.location.href = "/rooms";
+  });
+  document.getElementById("btnCancel")?.addEventListener("click", () => {
+    clearPersistedFiles();
+    clearTextDraft();
+    window.location.href = "/members/mypage";
+  });
+
+  setupImagePreview();
+  setupAddressSearch();
+  await loadRoomTypes();
+
+  const textDraft = loadTextDraft();
+  if (textDraft) {
+    applyTextDraft(textDraft);
+  }
+
+  setupDraftAutoSave();
+  document.getElementById("address")?.addEventListener("click", () => {
+    document.getElementById("btnAddrSearch")?.click();
+  });
+
+  document.getElementById("roomCreateForm")?.addEventListener("submit", submitRoom);
+});

--- a/src/main/webapp/resources/js/room/roomDetail.js
+++ b/src/main/webapp/resources/js/room/roomDetail.js
@@ -388,7 +388,7 @@ function renderRoomDetail(room) {
   const authorViewsEl = document.getElementById("author-views");
   if (authorViewsEl) authorViewsEl.innerText = views;
 
-  const authorName = room.ownerNickname ?? room.owner_nickname ?? "작성자";
+  const authorName = room.ownerName ?? room.owner_name ?? "작성자";
   const authorPhoto = room.ownerPhotoUrl ?? room.owner_photo_url ?? "";
   const authorPhotoEl = document.getElementById("author-photo");
   if (authorPhotoEl) authorPhotoEl.src = authorPhoto || "/resources/img/default-user.png";


### PR DESCRIPTION
## 작업 배경 (Background)

본 PR은 룸메이트 매칭 서비스의 핵심 사용자 흐름인

**방 등록 → 관리 → 조회 → 사용자 온보딩(회원가입/로그인)**

을 MVP 수준에서 하나의 일관된 흐름으로 완성하는 것을 목표로 진행되었습니다.

사용자 입력 도중 발생할 수 있는 다음 상황에서도  
**데이터 무결성과 서버 리소스 안정성**을 보장하는 구조를 중점적으로 정리했습니다.

- 입력 중 이탈
- 새로고침 / 탭 이동
- 취소
- 네트워크 오류

---

## PR 범위 요약

이번 PR에서는 아래 기능들을 하나의 사용자 경험 흐름으로 연결했습니다.

- 방 등록
- 마이페이지 내 게시글 관리
- 회원가입 / 로그인 / 개인정보 수정
- 이미지 업로드 전반 (안정화 구조 포함)

---

## 주요 기능 구현 내용

### 1. 방 등록 기능 (Room Create)

#### 프론트엔드

- `room-create.jsp` 신규 구현
- 카드(Card) 단위 레이아웃으로 입력 영역 분리
  - 기본 정보
  - 위치 정보
  - 방 정보
  - 이미지 업로드 (MVP)

#### 클라이언트 검증 로직

- 필수값 입력 체크
- 숫자 필드 음수 입력 방지
- 중복 제출 방지
- submit 버튼 loading 상태 관리

#### 주소 입력 개선

- 카카오(다음) 주소 검색 팝업 적용
- 직접 입력 방식 제거
- 도로명 / 지번 주소 중 우선값 적용
- 주소 + 상세주소 병합 후 서버 전송
- 법정동(`legalDong`) 분리 저장
- 향후 좌표(lat/lng) 변환 확장을 고려한 구조

---

## 이미지 업로드 구조 개선 (MVP → 안정화)

### 설계 배경

회원가입 / 방 등록 / 개인정보 수정 과정에서  
다음 상황이 발생하더라도 불필요한 이미지 파일이 서버에 남지 않도록 처리했습니다.

- 중간 이탈
- 새로고침
- 취소
- 네트워크 오류

이를 위해 이미지 저장 시점을 **업로드 단계**와 **확정 단계**로 분리했습니다.

---

## 이미지 임시 업로드 → 확정 저장 구조

### 공통 처리 흐름

#### 1) 임시 업로드

- `/upload/temp/profile`
- `/upload/temp/room`

임시 디렉토리에 저장 후  
`temp_upload_files` 테이블에서 메타데이터를 관리합니다.

#### 2) 사용자 확정 시

- 임시 파일을 영구 디렉토리로 이동
  - `/upload/profile`
  - `/upload/room`
- 실제 도메인 테이블에만 URL 저장
  - `members.photo_url`
  - `room_images`

#### 3) 정리

- 사용 완료된 temp 파일 및 DB 레코드 즉시 삭제
- 일정 시간 이상 미사용 temp 파일은 스케줄러로 자동 정리

---

## 회원가입 / 로그인 이미지 처리 확장

### 회원가입 이미지

회원가입 중 업로드한 이미지는 `signupKey(UUID)` 기준으로 관리합니다.

프론트 draft key 네임스페이스 분리

draft:auth:signupPhoto:<signupKey>:v1


### UX 흐름

- 새로고침 / 탭 이동 시 이전 이미지 불러오기 여부 선택
- 불러오지 않음 선택 시
  - 임시 파일 및 draft 즉시 삭제
- 회원가입 성공 시
  - temp → profile 이동
  - `members.photo_url` 업데이트
  - 관련 temp 데이터 전부 정리

---

### 로그인 / 토큰 안정화

- 페이지 로드 시 토큰 상태 동기화
- access token 만료 시 refresh 처리
- refresh 실패 시 토큰 정리 후 로그인 유도
- 회원가입/로그인 이미지 draft와 방 등록 이미지 draft 간 혼입 방지

---

### 개인정보 수정 (마이페이지)

- 프로필 사진 변경은 즉시 서버 반영 방식
- draft 저장 로직 미사용
- 회원가입/방 등록 이미지 처리 로직과 책임 분리
- 동일 이미지 재선택 UX 개선

---

## Room 도메인 백엔드 API

### REST API

- `POST /api/rooms` : 방 등록
- `GET /api/rooms/{roomId}` : 방 상세 조회
- `GET /api/rooms/me` : 내가 등록한 방 목록
- `PUT /api/rooms/{roomId}` : 방 수정
- `DELETE /api/rooms/{roomId}` : 방 삭제 (Soft Delete)
- `PATCH /api/rooms/{roomId}/status` : 상태 변경

### 권한 처리

- 모든 Room 변경 API는 로그인 필수
- 작성자 본인만 수정/삭제 가능하도록 검증

---

## MyBatis Repository & Query 정리

- `RoomRepository` 메서드 구조 정리
  - insert / update / soft delete / 상태 변경
- 작성자 기준 조회 쿼리
- 마이페이지 전용 DTO 매핑
- 썸네일 이미지 1장 서브쿼리 조회
- 최신 등록 순 정렬
- 삭제된 방 제외 처리

---

## 마이페이지 – 내 게시글

- 카드형 리스트 UI
  - 썸네일 / 제목 / 주소 / 가격 / 상태 배지
- 카드 클릭 시 상세 페이지 이동
- 삭제 버튼 동작 흐름
  - confirm → soft delete → 목록 갱신
- 빈 목록 시 안내 메시지 표시
