### PR TITLE
feat: 방 수정 기능 추가 및 이미지 수정/정리 구조 개선

### DIFF
--- a/src/main/java/com/roommate/domain/file/scheduler/RoomImageGcScheduler.java
+++ b/src/main/java/com/roommate/domain/file/scheduler/RoomImageGcScheduler.java
@@ -1,0 +1,17 @@
+package com.roommate.domain.file.scheduler;
+
+import com.roommate.domain.file.service.RoomFileGcService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoomImageGcScheduler {
+    private final RoomFileGcService roomFileGcService;
+
+    @Scheduled(cron = "0 30 3 * * *") // 매일 새벽 3:30
+    public void cleanupRoomOrphans() {
+        roomFileGcService.cleanupOrphanRoomFiles();
+    }
+}

--- a/src/main/java/com/roommate/domain/file/service/FileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/FileStorageService.java
@@ -2,6 +2,8 @@ package com.roommate.domain.file.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface FileStorageService {
 
     String storeProfileImg(Long memberId, MultipartFile multipartFile);
@@ -15,4 +17,6 @@ public interface FileStorageService {
     String moveTempProfileToProfile(Long memberId, String tempUrl);
 
     String moveTempRoomToRoom(Long roomId, String tempUrl);
+
+    List<String> listRoomImageUrls();
 }

--- a/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
+++ b/src/main/java/com/roommate/domain/file/service/LocalFileStorageService.java
@@ -13,6 +13,8 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -161,5 +163,22 @@ public class LocalFileStorageService implements FileStorageService {
         }
 
         return "/upload/" + targetDir + "/" + destName;
+    }
+
+    @Override
+    public List<String> listRoomImageUrls() {
+        File dir = new File(uploadRootPath, "room");
+        if (!dir.exists() || !dir.isDirectory()) return List.of();
+
+        File[] files = dir.listFiles();
+        if (files == null) return List.of();
+
+        List<String> urls = new ArrayList<>();
+        for (File f : files) {
+            if (f.isFile()) {
+                urls.add("/upload/room/" + f.getName());
+            }
+        }
+        return urls;
     }
 }

--- a/src/main/java/com/roommate/domain/file/service/RoomFileGcService.java
+++ b/src/main/java/com/roommate/domain/file/service/RoomFileGcService.java
@@ -1,0 +1,7 @@
+package com.roommate.domain.file.service;
+
+public interface RoomFileGcService {
+
+    public void cleanupOrphanRoomFiles();
+
+}

--- a/src/main/java/com/roommate/domain/file/service/RoomFileGcServiceImpl.java
+++ b/src/main/java/com/roommate/domain/file/service/RoomFileGcServiceImpl.java
@@ -1,0 +1,36 @@
+package com.roommate.domain.file.service;
+
+import com.roommate.domain.room.repository.RoomImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class RoomFileGcServiceImpl implements RoomFileGcService{
+
+    private final RoomImageRepository roomImageRepository;
+    private final FileStorageService fileStorageService;
+
+    @Override
+    @Transactional
+    public void cleanupOrphanRoomFiles() {
+        // 1) DB에서 참조 중인 url들
+        List<String> referenced = roomImageRepository.findAllImageUrls();
+        Set<String> referencedSet = new HashSet<>(referenced);
+
+        // 2) 디스크에 존재하는 room 파일들
+        List<String> diskUrls = fileStorageService.listRoomImageUrls(); // 위에 추가한 메서드
+
+        // 3) 디스크에는 있는데 DB에 없으면 삭제 대상
+        for (String url : diskUrls) {
+            if (!referencedSet.contains(url)) {
+                fileStorageService.deleteByUrl(url);
+            }
+        }
+    }
+}

--- a/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
+++ b/src/main/java/com/roommate/domain/room/controller/RoomViewController.java
@@ -47,7 +47,7 @@ public class RoomViewController {
     }
 
     /**
-     * 방 상세 페이지 (추후 구현용)
+     * 방 상세 페이지
      */
     @GetMapping("/{roomId}")
     public String roomDetailView(@PathVariable Long roomId, Model model) {
@@ -63,5 +63,12 @@ public class RoomViewController {
     @GetMapping("/roomCreate")
     public String roomCreateView(){
         return "rooms/roomCreate";
+    }
+
+    @GetMapping("/{roomId}/edit")
+    public String roomEditView(@PathVariable Long roomId, Model model) {
+        model.addAttribute("roomId", roomId);
+        model.addAttribute("kakaoJsKey", kakaoJsKey);
+        return "rooms/roomEdit";
     }
 }

--- a/src/main/java/com/roommate/domain/room/repository/RoomImageRepository.java
+++ b/src/main/java/com/roommate/domain/room/repository/RoomImageRepository.java
@@ -24,4 +24,8 @@ public interface RoomImageRepository {
      */
     List<String> findImageUrlsByRoomId(@Param("roomId") Long roomId);
 
+    /**
+     * 모든 이미지 조회
+     */
+    List<String> findAllImageUrls();
 }

--- a/src/main/java/com/roommate/domain/room/service/RoomImageService.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomImageService.java
@@ -9,6 +9,7 @@ public interface RoomImageService {
      */
     void attachTempImagesToRoom(Long roomId, Long memberId, List<Long> tempFileIds);
 
+    void updateRoomImages(Long roomId, Long memberId, List<String> keepImageUrls, List<Long> tempFileIds);
     /**
      * 방 수정 시: 기존 이미지를 전체 교체한다.
      * (지금 정책 그대로 유지)

--- a/src/main/java/com/roommate/domain/room/service/RoomImageServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomImageServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class RoomImageServiceImpl implements RoomImageService{
+public class RoomImageServiceImpl implements RoomImageService {
     private final RoomImageRepository roomImageRepository;
     private final TempUploadFileService tempUploadFileService;
 
@@ -29,7 +29,7 @@ public class RoomImageServiceImpl implements RoomImageService{
 
         for (Long tempFileId : tempFileIds) {
             // 왜: 남의 temp 파일 도용 방지 + used=1 확정
-            String url = tempUploadFileService.useTempFileForRoom(tempFileId, memberId,roomId);
+            String url = tempUploadFileService.useTempFileForRoom(tempFileId, memberId, roomId);
             imageUrls.add(url);
         }
 
@@ -57,5 +57,27 @@ public class RoomImageServiceImpl implements RoomImageService{
     @Transactional(readOnly = true)
     public List<String> findImageUrlsByRoomId(Long roomId) {
         return roomImageRepository.findImageUrlsByRoomId(roomId);
+    }
+
+    @Override
+    @Transactional
+    public void updateRoomImages(Long roomId, Long memberId, List<String> keepImageUrls, List<Long> tempFileIds) {
+        List<String> finalUrls = new ArrayList<>();
+
+        // 1) 유지할 기존 이미지
+        if (keepImageUrls != null && !keepImageUrls.isEmpty()) {
+            finalUrls.addAll(keepImageUrls);
+        }
+
+        // 2) 새 temp 이미지 확정
+        if (tempFileIds != null && !tempFileIds.isEmpty()) {
+            for (Long tempFileId : tempFileIds) {
+                String url = tempUploadFileService.useTempFileForRoom(tempFileId, memberId, roomId);
+                finalUrls.add(url);
+            }
+        }
+
+        // 3) 최종 목록으로 교체(삭제/추가 모두 반영)
+        replaceRoomImages(roomId, finalUrls);
     }
 }

--- a/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
@@ -183,8 +183,7 @@ public class RoomServiceImpl implements RoomService {
 
         roomRepository.updateRoom(roomEntity);
 
-        // 이미지 전체 교체 정책
-        roomImageService.attachTempImagesToRoom(roomId, memberId, roomUpdateRequest.getTempFileIds());
+        roomImageService.updateRoomImages(roomId, memberId, roomUpdateRequest.getImageUrls(), roomUpdateRequest.getTempFileIds());
     }
 
     @Override

--- a/src/main/resources/mapper/room_image/RoomImage.xml
+++ b/src/main/resources/mapper/room_image/RoomImage.xml
@@ -48,4 +48,10 @@
         ORDER BY sort_order ASC, image_id ASC
     </select>
 
+    <select id="findAllImageUrls" resultType="string">
+        SELECT image_url
+        FROM room_image
+        WHERE deleted = 0
+    </select>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/views/rooms/roomEdit.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/roomEdit.jsp
@@ -3,8 +3,9 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8"/>
-  <title>방 등록 | 룸메이트</title>
+  <title>방 수정 | 룸메이트</title>
   <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/room/room-form.css"/>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/room/room-edit.css"/>
 </head>
 <body>
 <jsp:include page="/WEB-INF/views/common/header.jsp"/>
@@ -14,10 +15,11 @@
     <button type="button" id="btn-back" class="btn-link">← 마이페이지로</button>
   </div>
 
-  <h1 class="page-title">방 등록하기</h1>
-  <p class="page-subtitle">룸메이트를 찾기 위한 방 정보를 등록해주세요</p>
+  <h1 class="page-title">방 수정하기</h1>
+  <p class="page-subtitle">룸메이트를 찾기 위한 방 정보를 입력해주세요</p>
 
-  <form id="roomCreateForm" class="form" novalidate>
+  <form id="roomEditForm" class="form" novalidate>
+    <input type="hidden" id="roomId" value="${roomId}" />
     <section class="card">
       <div class="card-head">
         <h2 class="card-title">기본 정보</h2>
@@ -122,13 +124,13 @@
 
     <div class="bottom-actions">
       <button type="button" id="btnCancel" class="btn btn-ghost">취소</button>
-      <button type="submit" class="btn btn-primary">방 등록하기</button>
+      <button type="submit" class="btn btn-primary">방 수정하기</button>
     </div>
   </form>
 </main>
 
 <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
-<script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomCreate.js"></script>
+<script type="module" src="${pageContext.request.contextPath}/resources/js/room/roomEdit.js"></script>
 <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/room/room-edit.css
+++ b/src/main/webapp/resources/css/room/room-edit.css
@@ -1,0 +1,11 @@
+/* /resources/css/room/room-edit.css */
+.edit-warning{
+  margin-top: 10px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background:#fff7ed;
+  border:1px solid #fed7aa;
+  color:#9a3412;
+  font-size: 13px;
+  font-weight: 700;
+}

--- a/src/main/webapp/resources/css/room/room-form.css
+++ b/src/main/webapp/resources/css/room/room-form.css
@@ -1,5 +1,5 @@
-/* /resources/css/room/room-create.css */
-.room-create-main{
+/* /resources/css/room/room-form.css */
+.room-form-main{
   max-width: 1060px;
   margin: 28px auto 60px;
   padding: 0 16px;
@@ -258,6 +258,17 @@
 }
 .btn-primary:hover{
   filter: brightness(1.05);
+}
+.btn-link{
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 700;
+  color: #111827;
+}
+.btn-link:hover{
+  opacity: .85;
 }
 
 @media (max-width: 900px){

--- a/src/main/webapp/resources/js/common/formUtils.js
+++ b/src/main/webapp/resources/js/common/formUtils.js
@@ -1,0 +1,23 @@
+// formUtils.js
+// 공용 폼 입력 유틸
+
+// value: 문자열(trim)
+export function v(id) {
+  return (document.getElementById(id)?.value ?? "").trim();
+}
+
+// number: 숫자 or null
+export function n(id) {
+  const s = v(id);
+  if (s === "") return null;
+  const num = Number(s);
+  return Number.isFinite(num) ? num : null;
+}
+
+// integer: 정수 or null
+export function i(id) {
+  const s = v(id);
+  if (s === "") return null;
+  const num = Number(s);
+  return Number.isFinite(num) ? Math.trunc(num) : null;
+}

--- a/src/main/webapp/resources/js/room/roomCreate.js
+++ b/src/main/webapp/resources/js/room/roomCreate.js
@@ -3,6 +3,7 @@
 import { apiRequest } from "../common/apiClient.js";
 import { requireLogin } from "../common/authGuard.js";
 import { makeUserScope, makeDraftKey, saveDraft, loadDraft, clearDraft } from "../common/draftStore.js";
+import { v, n, i } from "../common/formUtils.js";
 
 let selectedFiles = [];
 
@@ -18,19 +19,6 @@ const IMG_PAGE = `${PAGE}:images`;
 
 const TEXT_KEY = makeDraftKey({ app: APP, page: TEXT_PAGE, userScope: USER_SCOPE, version: VERSION });
 const IMG_KEY  = makeDraftKey({ app: APP, page: IMG_PAGE, userScope: USER_SCOPE, version: VERSION });
-
-// ===== utils =====
-function v(id) {
-  return (document.getElementById(id)?.value ?? "").trim();
-}
-function n(id) {
-  const x = v(id);
-  return x === "" ? null : Number(x);
-}
-function i(id) {
-  const x = v(id);
-  return x === "" ? null : parseInt(x, 10);
-}
 
 function validate(payload) {
   if (!payload.title) return "제목은 필수입니다.";

--- a/src/main/webapp/resources/js/room/roomDetail.js
+++ b/src/main/webapp/resources/js/room/roomDetail.js
@@ -191,8 +191,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   const backBtn = document.getElementById("btn-back");
   if (backBtn) {
     backBtn.addEventListener("click", () => {
-      if (history.length > 1) history.back();
-      else location.href = "/rooms/map";
+      location.href = "/rooms/map";
     });
   }
 
@@ -210,6 +209,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   applyActionVisibility(currentRoom);
 
   bindActionsOnce(roomId);
+  bindDetailActions();
 });
 
 function bindActionsOnce(roomId) {
@@ -273,6 +273,77 @@ function bindActionsOnce(roomId) {
       const ownerId = currentRoom?.ownerId ?? currentRoom?.owner_id ?? null;
       if (!ownerId) return;
       alert(`작성자 프로필 페이지로 이동 예정 (memberId=${ownerId})`);
+    });
+  }
+  // 게시글 수정 (owner 전용)
+  const editBtn = document.getElementById("btn-detail-edit");
+  if (editBtn) {
+    editBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const ok = requireLogin();
+      if (!ok) return;
+
+      // owner만 보이게 되어있지만, 혹시 몰라 한번 더 방어
+      if (!isOwnerOfRoom(currentRoom)) {
+        alert("작성자만 수정할 수 있습니다.");
+        return;
+      }
+
+      location.href = `/rooms/${roomId}/edit`;
+    });
+  }
+  // 게시글 삭제 (owner 전용)
+  const deleteBtn = document.getElementById("btn-detail-delete");
+  if (deleteBtn) {
+    deleteBtn.addEventListener("click", async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const ok = requireLogin();
+      if (!ok) return;
+
+      if (!isOwnerOfRoom(currentRoom)) {
+        alert("작성자만 삭제할 수 있습니다.");
+        return;
+      }
+
+      const confirmed = confirm("게시글을 삭제하면 더 이상 노출되지 않습니다.\n정말 삭제하시겠습니까?");
+      if (!confirmed) return;
+
+      if (deleteBtn.dataset.loading === "true") return;
+      deleteBtn.dataset.loading = "true";
+      deleteBtn.disabled = true;
+
+      try {
+        const res = await apiRequest(`/api/rooms/${roomId}`, { method: "DELETE" });
+
+        if (res.status === 401) {
+          alert("로그인이 필요합니다.");
+          location.href = "/members/login";
+          return;
+        }
+        if (res.status === 403) {
+          alert("작성자만 삭제할 수 있습니다.");
+          location.href = "/members/mypage";
+          return;
+        }
+        if (!res.ok) {
+          alert("삭제에 실패했습니다.");
+          return;
+        }
+
+        alert("삭제되었습니다.");
+        // 삭제 후 이동 정책은 팀 기준에 맞춰 선택
+        location.href = "/members/mypage"; // 또는 "/rooms/map"
+      } catch (err) {
+        console.error(err);
+        alert("삭제 중 오류가 발생했습니다.");
+      } finally {
+        deleteBtn.dataset.loading = "false";
+        deleteBtn.disabled = false;
+      }
     });
   }
 }
@@ -412,4 +483,106 @@ function renderRoomDetail(room) {
   const ownerTags = room.ownerTags ?? room.owner_tags ?? [];
   renderChips(chipContainer, ownerTags, { max: 8, emptyText: "선호 태그 없음" });
   applyActionVisibility(room);
+}
+
+function bindDetailActions() {
+  const toggleBtn = document.getElementById("btn-detail-toggle-status");
+  if (!toggleBtn) return;
+
+  toggleBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const ok = requireLogin();
+    if (!ok) return;
+
+    const { roomId } = getRoomMeta();
+    if (!roomId) {
+      alert("roomId를 찾을 수 없습니다.");
+      return;
+    }
+
+    if (!isOwnerOfRoom(currentRoom)) {
+      alert("작성자만 마감/재개할 수 있습니다.");
+      return;
+    }
+
+    const pill = document.getElementById("room-status-pill");
+    if (!pill) {
+      alert("상태 표시 요소를 찾지 못했습니다.");
+      return;
+    }
+
+    const currentStatus =
+      pill.classList.contains("room-status-OPEN") ? "OPEN" :
+      pill.classList.contains("room-status-RESERVED") ? "RESERVED" :
+      pill.classList.contains("room-status-CLOSED") ? "CLOSED" :
+      pill.classList.contains("room-status-HIDDEN") ? "HIDDEN" :
+      "OPEN"; // 기본값
+
+    if (currentStatus === "RESERVED" || currentStatus === "HIDDEN") {
+      alert("현재 상태에서는 변경할 수 없습니다.");
+      return;
+    }
+
+    const nextStatus = currentStatus === "OPEN" ? "CLOSED" : "OPEN";
+    const confirmMsg = nextStatus === "CLOSED" ? "모집을 마감할까요?" : "모집을 재개할까요?";
+    if (!confirm(confirmMsg)) return;
+
+    if (toggleBtn.dataset.loading === "true") return;
+    toggleBtn.dataset.loading = "true";
+    toggleBtn.disabled = true;
+
+    try {
+      const res = await apiRequest(`/api/rooms/${roomId}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+
+      if (res.status === 401) {
+        alert("로그인이 필요합니다.");
+        location.href = "/members/login";
+        return;
+      }
+      if (res.status === 403) {
+        alert("작성자만 변경할 수 있습니다.");
+        return;
+      }
+      if (!res.ok) {
+        const msg = await res.text().catch(() => "");
+        alert("상태 변경 실패" + (msg ? `: ${msg}` : ""));
+        return;
+      }
+
+      pill.classList.remove(
+        "room-status-OPEN",
+        "room-status-RESERVED",
+        "room-status-CLOSED",
+        "room-status-HIDDEN"
+      );
+      pill.classList.add(`room-status-${nextStatus}`);
+      pill.textContent = statusText(nextStatus);
+
+      toggleBtn.textContent = nextStatus === "OPEN" ? "모집 마감" : "모집 재개";
+
+      if (currentRoom) currentRoom.status = nextStatus;
+    } catch (err) {
+      console.error(err);
+      alert("상태 변경 중 오류가 발생했습니다.");
+    } finally {
+      toggleBtn.dataset.loading = "false";
+      toggleBtn.disabled = false;
+    }
+  });
+}
+
+function statusText(status) {
+  switch (status) {
+    case "OPEN": return "모집중";
+    case "RESERVED": return "예약중";
+    case "CLOSED": return "마감";
+    case "HIDDEN": return "비공개";
+    default: return status;
+  }
 }

--- a/src/main/webapp/resources/js/room/roomEdit.js
+++ b/src/main/webapp/resources/js/room/roomEdit.js
@@ -1,0 +1,349 @@
+// /resources/js/room/roomEdit.js
+import { apiRequest } from "../common/apiClient.js";
+import { requireLogin } from "../common/authGuard.js";
+import { v, n, i } from "../common/formUtils.js";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const ok = requireLogin();
+  if (!ok) return;
+
+  const roomId = getRoomIdFromHidden();
+  if (!roomId) {
+    alert("잘못된 접근입니다.");
+    location.href = "/members/mypage";
+    return;
+  }
+
+  bindNavButtons();
+  bindAddressSearch();
+
+  const existingImageUrls = [];
+  const newImageUrls = [];
+  const tempFileIds = [];
+
+  try {
+    await loadRoomTypes();
+    await loadRoomDetailAndFill(roomId, existingImageUrls);
+    renderAllImages(existingImageUrls, newImageUrls, tempFileIds);
+    bindImagePicker(existingImageUrls, newImageUrls, tempFileIds);
+  } catch (e) {
+    console.error(e);
+    alert("수정 페이지 초기화에 실패했습니다.");
+    location.href = "/members/mypage";
+    return;
+  }
+
+  bindSubmit(roomId, existingImageUrls, newImageUrls, tempFileIds);
+});
+
+/* ------------------------------
+ *  Basic Utils
+ * ------------------------------ */
+
+function getRoomIdFromHidden() {
+  const raw = document.getElementById("roomId")?.value;
+  const id = Number(raw);
+  return Number.isFinite(id) ? id : null;
+}
+
+function setValue(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.value = val ?? "";
+}
+
+function setSelect(id, val) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.value = String(val ?? "");
+}
+
+function toDateInputValue(raw) {
+  return String(raw).slice(0, 10);
+}
+
+/* ------------------------------
+ *  Navigation
+ * ------------------------------ */
+
+function bindNavButtons() {
+  const back = document.getElementById("btn-back");
+  const cancel = document.getElementById("btnCancel");
+
+  const goMypage = () => (location.href = "/members/mypage");
+
+  back?.addEventListener("click", goMypage);
+  cancel?.addEventListener("click", goMypage);
+}
+
+/* ------------------------------
+ *  Load Room Types
+ * ------------------------------ */
+
+async function loadRoomTypes() {
+  const select = document.getElementById("roomTypeId");
+  if (!select) return;
+
+  const res = await apiRequest("/api/room-types", { method: "GET" });
+  if (!res.ok) throw new Error("room types load failed: " + res.status);
+
+  const list = await res.json();
+  list.forEach((rt) => {
+    const opt = document.createElement("option");
+    opt.value = rt.roomTypeId ?? rt.room_type_id;
+    opt.textContent = rt.roomTypeName ?? rt.room_type_name;
+    select.appendChild(opt);
+  });
+}
+
+/* ------------------------------
+ *  Load Room Detail & Fill Form
+ * ------------------------------ */
+
+async function loadRoomDetailAndFill(roomId, existingImageUrls) {
+  const res = await apiRequest(`/api/rooms/${roomId}`, { method: "GET" });
+
+  if (res.status === 401) {
+    alert("로그인이 필요합니다.");
+    location.href = "/members/login";
+    throw new Error("unauthorized");
+  }
+  if (res.status === 403) {
+    alert("작성자만 수정할 수 있습니다.");
+    location.href = "/members/mypage";
+    throw new Error("forbidden");
+  }
+  if (!res.ok) {
+    alert("방 정보를 불러올 수 없습니다.");
+    location.href = "/members/mypage";
+    throw new Error("load failed");
+  }
+
+  const data = await res.json();
+
+  // 값 채우기
+  setValue("title", data.title ?? data.roomTitle ?? "");
+  setValue("content", data.content ?? data.roomContent ?? "");
+  setValue("address", data.address ?? "");
+  setValue("legalDong", data.legalDong ?? data.legal_dong ?? "");
+  setValue("landNumber", data.landNumber ?? data.land_number ?? "");
+
+  setValue("monthlyRent", data.monthlyRent ?? data.monthly_rent ?? 0);
+  setValue("deposit", data.deposit ?? 0);
+  setValue("areaM2", data.areaM2 ?? data.area_m2 ?? 0);
+  setValue("floor", data.floor ?? "");
+  setValue("maxRoommates", data.maxRoommates ?? data.max_roommates ?? "");
+
+  setSelect("roomTypeId", data.roomTypeId ?? data.room_type_id ?? "");
+
+  const availableFrom = data.availableFrom ?? data.available_from;
+  if (availableFrom) setValue("availableFrom", toDateInputValue(availableFrom));
+
+  const urls = data.imageUrls ?? data.image_urls ?? [];
+  existingImageUrls.splice(0, existingImageUrls.length, ...(Array.isArray(urls) ? urls : []));
+}
+
+/* ------------------------------
+ *  Address Search (Daum Postcode)
+ * ------------------------------ */
+
+function bindAddressSearch() {
+  const btn = document.getElementById("btnAddrSearch");
+  const address = document.getElementById("address");
+
+  const openPostcode = () => {
+    new daum.Postcode({
+      oncomplete: function (data) {
+        setValue("address", data.address || "");
+        setValue("legalDong", data.bname || "");
+        setValue("landNumber", data.jibunAddress || "");
+      },
+    }).open();
+  };
+
+  btn?.addEventListener("click", openPostcode);
+  address?.addEventListener("click", openPostcode);
+}
+
+/* ------------------------------
+ *  Image Rendering (Existing + New)
+ * ------------------------------ */
+
+function renderAllImages(existingImageUrls, newImageUrls, tempFileIds) {
+  const grid = document.getElementById("previewGrid");
+  if (!grid) return;
+
+  grid.innerHTML = "";
+
+  existingImageUrls.forEach((url) => {
+    const item = createPreviewItem(url, () => {
+      const index = existingImageUrls.indexOf(url);
+      if (index !== -1) existingImageUrls.splice(index, 1);
+      renderAllImages(existingImageUrls, newImageUrls, tempFileIds);
+    });
+    grid.appendChild(item);
+  });
+
+  newImageUrls.forEach((url) => {
+    const item = createPreviewItem(url, () => {
+      const index = newImageUrls.indexOf(url);
+      if (index !== -1) {
+        newImageUrls.splice(index, 1);
+        tempFileIds.splice(index, 1); // tempFileIds는 newImageUrls랑 같은 인덱스
+      }
+      renderAllImages(existingImageUrls, newImageUrls, tempFileIds);
+    });
+    grid.appendChild(item);
+  });
+}
+
+function createPreviewItem(url, onRemove) {
+  const item = document.createElement("div");
+  item.className = "preview-item";
+
+  const img = document.createElement("img");
+  img.src = url;
+  img.alt = "preview";
+
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "preview-remove";
+  btn.textContent = "삭제";
+  btn.addEventListener("click", onRemove);
+
+  item.appendChild(img);
+  item.appendChild(btn);
+  return item;
+}
+
+/* ------------------------------
+ *  Temp Upload (New Images)
+ * ------------------------------ */
+
+function bindImagePicker(existingImageUrls, newImageUrls, tempFileIds) {
+  const input = document.getElementById("photoInput");
+  if (!input) return;
+
+  input.addEventListener("change", async (e) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+
+    try {
+      for (const file of files) {
+        const uploaded = await uploadTempRoomImage(file);
+
+        const tempId = uploaded?.temp_file_id;
+        const url = uploaded?.temp_url;
+
+        const hasTempId = tempId !== null && tempId !== undefined && String(tempId).trim() !== "";
+        const hasUrl = typeof url === "string" && url.trim() !== "";
+
+        if (hasTempId && hasUrl) {
+          tempFileIds.push(Number(tempId));
+          newImageUrls.push(url);
+        } else {
+          throw new Error("temp upload response invalid");
+        }
+      }
+
+      renderAllImages(existingImageUrls, newImageUrls, tempFileIds);
+    } catch (err) {
+      console.error(err);
+      alert("이미지 업로드에 실패했습니다.");
+    } finally {
+      input.value = "";
+    }
+  });
+}
+
+async function uploadTempRoomImage(file) {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await apiRequest("/api/files/temp/room", {
+    method: "PUT",
+    body: formData,
+  });
+
+  if (!res.ok) throw new Error("temp upload fail: " + res.status);
+
+  const data = await res.json();
+  return {
+    temp_file_id: data.temp_file_id ?? data.tempFileId,
+    temp_url: data.temp_url ?? data.tempUrl ?? data.temp_path ?? data.tempPath,
+  };
+}
+
+/* ------------------------------
+ *  Submit (PUT /api/rooms/{roomId})
+ * ------------------------------ */
+
+function bindSubmit(roomId, existingImageUrls, newImageUrls, tempFileIds) {
+  const form = document.getElementById("roomEditForm");
+  if (!form) return;
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+
+    const fullAddress = buildFullAddress();
+
+    const keepImageUrls = existingImageUrls.filter((x) => typeof x === "string" && x.trim() !== "");
+    const validTempFileIds = tempFileIds.filter((x) => Number.isFinite(Number(x)));
+
+    const payload = {
+      title: v("title"),
+      content: v("content"),
+
+      room_type_id: n("roomTypeId"),
+      monthly_rent: n("monthlyRent"),
+      deposit: n("deposit"),
+      area_m2: n("areaM2"),
+      floor: i("floor"),
+
+      address: fullAddress,
+      legal_dong: v("legalDong") || null,
+      land_number: v("landNumber") || null,
+      available_from: v("availableFrom") || null,
+      max_roommates: i("maxRoommates"),
+
+      image_urls: keepImageUrls,
+      temp_file_ids: validTempFileIds,
+    };
+
+    // 최소 검증
+    if (!payload.title || !payload.content || !payload.address || !payload.room_type_id) {
+      alert("필수 항목(제목/설명/주소/방타입)을 입력해 주세요.");
+      return;
+    }
+
+    const res = await apiRequest(`/api/rooms/${roomId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (res.status === 401) {
+      alert("로그인이 필요합니다.");
+      location.href = "/members/login";
+      return;
+    }
+    if (res.status === 403) {
+      alert("작성자만 수정할 수 있습니다.");
+      location.href = "/members/mypage";
+      return;
+    }
+    if (!res.ok) {
+      alert("수정에 실패했습니다.");
+      return;
+    }
+
+    alert("수정되었습니다.");
+    location.replace(`/rooms/${roomId}`);
+  });
+}
+
+function buildFullAddress() {
+  const base = v("address");
+  const detail = v("addressDetail");
+  if (!detail) return base;
+  return `${base} ${detail}`.trim();
+}


### PR DESCRIPTION
## 작업 배경 (Background)

본 PR은 **방 상세 → 수정 → 이미지 관리 → 정리(GC)** 흐름을  
실제 서비스 수준으로 안정화하기 위한 작업입니다.

기존 구현에서는 방 수정 시 다음과 같은 문제가 있었습니다.

- 기존 이미지를 유지한 채 새 이미지 추가 불가
- 이미지 삭제는 가능하지만 실제 파일은 서버에 잔존
- 생성 로직과 수정 로직이 동일해 책임이 불명확
- 뒤로가기 시 수정 페이지로 다시 이동되는 UX 문제

이번 PR에서는 위 문제를 해결하면서  
**방 수정 전용 이미지 처리 구조와 서버 정리 전략**을 명확히 분리했습니다.

---

## PR 범위 요약

- 방 수정 페이지(`roomEdit`) 신규 구현
- 방 수정 시 이미지 추가 / 유지 / 삭제 기능 완성
- 생성(Create) / 수정(Update) 이미지 처리 로직 분리
- Room 이미지 전용 GC(Garbage Collection) 도입
- 잘못된 뒤로가기 UX 수정

---

## 주요 구현 내용

## 1. 방 수정 페이지 구현 (Room Edit)

### View / Routing
- `/rooms/{roomId}/edit` 수정 페이지 신규 추가
- 작성자만 접근 가능
- 기존 방 정보 자동 로딩

### UX
- 수정 완료 시 상세 페이지(`/rooms/{roomId}`) 이동
- 취소 / 뒤로가기 시 목록(지도) 페이지로 이동

---

## 2. 방 수정 이미지 처리 구조 개선

### 기존 문제
- 새 이미지 추가 시 기존 이미지 전체 삭제
- 기존 이미지 개별 삭제 불가
- 실제 파일은 서버에 계속 남아 있음

### 개선 방향
- **유지할 기존 이미지 + 새 이미지**를 명확히 분리
- 수정 전용 이미지 처리 로직 도입

---

## 3. 프론트엔드 이미지 관리 방식

### 상태 분리
- `existingImageUrls` : 기존 이미지(URL 기준)
- `newImageUrls` : 새로 업로드한 이미지
- `tempFileIds` : 새 이미지에 대응하는 temp 파일 ID

### 동작 방식
- 기존 이미지: URL 기준으로 유지 / 삭제
- 새 이미지:
  - temp 업로드
  - 미리보기 표시
  - 삭제 시 temp 목록에서도 제거

### 서버 전송 데이터
```json
{
  "image_urls": ["유지할 기존 이미지 URL"],
  "temp_file_ids": [새로 업로드한 tempFileId]
}
