### PR TITLE
fix: 지도 및 목록 API에 roomTitle 누락 문제 수정

### DIFF
--- a/src/main/java/com/roommate/domain/room/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/roommate/domain/room/dto/request/RoomCreateRequest.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 public class RoomCreateRequest {
     @NotBlank
-    private String title;
+    private String roomTitle;
     @NotBlank
     private String content;
     @NotNull

--- a/src/main/java/com/roommate/domain/room/dto/request/RoomUpdateRequest.java
+++ b/src/main/java/com/roommate/domain/room/dto/request/RoomUpdateRequest.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class RoomUpdateRequest {
-    private String title;
+    private String roomTitle;
     private String content;
     private Long roomTypeId;
     private Double monthlyRent;

--- a/src/main/java/com/roommate/domain/room/dto/response/MyRoomListItemResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/MyRoomListItemResponse.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class MyRoomListItemResponse {
     private final Long roomId;
-    private final String title;
+    private final String roomTitle;
     private final String address;
     private final Double monthlyRent;
     private final Double deposit;

--- a/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/RoomDetailResponse.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class RoomDetailResponse {
 
     private final Long roomId;
-    private final String title;
+    private final String roomTitle;
     private final String content;
     private final Long roomTypeId;
     private final String roomTypeName;

--- a/src/main/java/com/roommate/domain/room/dto/response/RoomMapItemResponse.java
+++ b/src/main/java/com/roommate/domain/room/dto/response/RoomMapItemResponse.java
@@ -11,8 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class RoomMapItemResponse {
     private final Long roomId;
+    private final String roomTitle;
     private final Double lat;
     private final Double lng;
+    private final String address;
     private final Double monthlyRent;
     private final Double deposit;
     private final RoomStatusEnum status;

--- a/src/main/java/com/roommate/domain/room/entity/RoomDetailEntity.java
+++ b/src/main/java/com/roommate/domain/room/entity/RoomDetailEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 public class RoomDetailEntity {
     private Long roomId;
-    private String title;
+    private String roomTitle;
     private String content;
     private Long roomTypeId;
     private String roomTypeName;

--- a/src/main/java/com/roommate/domain/room/entity/RoomMapItemEntity.java
+++ b/src/main/java/com/roommate/domain/room/entity/RoomMapItemEntity.java
@@ -9,8 +9,10 @@ import lombok.*;
 @Builder
 public class RoomMapItemEntity {
     private Long roomId;
+    private String roomTitle;
     private Double lat;
     private Double lng;
+    private String address;
     private Double monthlyRent;
     private Double deposit;
     private RoomStatusEnum status;

--- a/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/roommate/domain/room/service/RoomServiceImpl.java
@@ -91,7 +91,7 @@ public class RoomServiceImpl implements RoomService {
     private RoomEntity toRoomEntity(RoomCreateRequest request, Long memberId, KakaoGeoPoint point) {
         RoomEntity roomEntity = new RoomEntity();
         roomEntity.setMemberId(memberId);
-        roomEntity.setRoomTitle(request.getTitle());
+        roomEntity.setRoomTitle(request.getRoomTitle());
         roomEntity.setRoomContent(request.getContent());
         roomEntity.setRoomTypeId(request.getRoomTypeId());
         roomEntity.setMonthlyRent(request.getMonthlyRent());
@@ -119,7 +119,7 @@ public class RoomServiceImpl implements RoomService {
      */
     private void applyUpdate(RoomEntity roomEntity, RoomUpdateRequest request) {
         KakaoGeoPoint point = resolveGeoPoint(request.getAddress());
-        roomEntity.setRoomTitle(request.getTitle());
+        roomEntity.setRoomTitle(request.getRoomTitle());
         roomEntity.setRoomContent(request.getContent());
         roomEntity.setRoomTypeId(request.getRoomTypeId());
         roomEntity.setMonthlyRent(request.getMonthlyRent());
@@ -218,7 +218,7 @@ public class RoomServiceImpl implements RoomService {
         if (roomDetailEntity.getLat() != null && roomDetailEntity.getLng() != null) {
             double lat = roomDetailEntity.getLat();
             double lng = roomDetailEntity.getLng();
-            String title = roomDetailEntity.getTitle();
+            String title = roomDetailEntity.getRoomTitle();
 
             kakaoMapUrl = buildKakaoMapUrl("map", title, lat, lng);
             kakaoDirectionUrl = buildKakaoMapUrl("to", title, lat, lng);
@@ -233,7 +233,7 @@ public class RoomServiceImpl implements RoomService {
 
         return new RoomDetailResponse(
                 roomDetailEntity.getRoomId(),
-                roomDetailEntity.getTitle(),
+                roomDetailEntity.getRoomTitle(),
                 roomDetailEntity.getContent(),
                 roomDetailEntity.getRoomTypeId(),
                 roomDetailEntity.getRoomTypeName(),
@@ -280,8 +280,10 @@ public class RoomServiceImpl implements RoomService {
         return roomMapItemEntities.stream().
                 map(roomMapItemEntity -> new RoomMapItemResponse(
                         roomMapItemEntity.getRoomId(),
+                        roomMapItemEntity.getRoomTitle(),
                         roomMapItemEntity.getLat(),
                         roomMapItemEntity.getLng(),
+                        roomMapItemEntity.getAddress(),
                         roomMapItemEntity.getMonthlyRent(),
                         roomMapItemEntity.getDeposit(),
                         roomMapItemEntity.getStatus(),

--- a/src/main/resources/mapper/room/Room.xml
+++ b/src/main/resources/mapper/room/Room.xml
@@ -91,8 +91,10 @@
     <select id="findForMap" resultType="com.roommate.domain.room.entity.RoomMapItemEntity">
         SELECT
         r.room_id       AS roomId,
+        r.room_title    AS roomTitle,
         r.lat           AS lat,
         r.lng           AS lng,
+        r.address       AS address,
         r.monthly_rent  AS monthlyRent,
         r.deposit       AS deposit,
         r.status        AS status,
@@ -111,7 +113,7 @@
     <select id="findMyRooms" resultType="com.roommate.domain.room.dto.response.MyRoomListItemResponse">
         SELECT
         r.room_id        AS roomId,
-        r.room_title     AS title,
+        r.room_title     AS roomTitle,
         r.address        AS address,
         r.monthly_rent   AS monthlyRent,
         r.deposit        AS deposit,
@@ -134,7 +136,7 @@
     <select id="findDetailById" resultType="com.roommate.domain.room.entity.RoomDetailEntity">
         SELECT
         r.room_id       AS roomId,
-        r.room_title    AS title,
+        r.room_title    AS roomTitle,
         r.room_content  AS content,
         r.room_type_id  AS roomTypeId,
         rt.room_type_name AS roomTypeName,

--- a/src/main/webapp/WEB-INF/views/rooms/roomCreate.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/roomCreate.jsp
@@ -26,7 +26,7 @@
 
       <div class="field">
         <label class="label">제목 <span class="req">*</span></label>
-        <input id="title" class="input" type="text" placeholder="예: 강남역 도보 5분, 투룸 룸메이트 구함"/>
+        <input id="roomTitle" class="input" type="text" placeholder="예: 강남역 도보 5분, 투룸 룸메이트 구함"/>
       </div>
 
       <div class="field">

--- a/src/main/webapp/WEB-INF/views/rooms/roomEdit.jsp
+++ b/src/main/webapp/WEB-INF/views/rooms/roomEdit.jsp
@@ -28,7 +28,7 @@
 
       <div class="field">
         <label class="label">제목 <span class="req">*</span></label>
-        <input id="title" class="input" type="text" placeholder="예: 강남역 도보 5분, 투룸 룸메이트 구함"/>
+        <input id="roomTitle" class="input" type="text" placeholder="예: 강남역 도보 5분, 투룸 룸메이트 구함"/>
       </div>
 
       <div class="field">
@@ -108,7 +108,7 @@
 
     <section class="card">
       <div class="card-head">
-        <h2 class="card-title">이미지 (MVP: 미리보기만)</h2>
+        <h2 class="card-roomTitle">이미지 (MVP: 미리보기만)</h2>
         <p class="card-desc">업로드 API 연결 시 imageUrls로 전송</p>
       </div>
 

--- a/src/main/webapp/resources/js/member/mypageView.js
+++ b/src/main/webapp/resources/js/member/mypageView.js
@@ -160,7 +160,7 @@ function renderFavoriteList(list) {
 
   list.forEach((room) => {
     const roomId = room.roomId ?? room.room_id;
-    const title = room.title ?? room.roomTitle ?? room.room_title ?? "제목 없음";
+    const title = room.roomTitle ?? room.room_title ?? room.title ?? "제목 없음";
     const address = room.address ?? "";
     const deposit = room.deposit;
     const monthlyRent = room.monthlyRent ?? room.monthly_rent;
@@ -180,7 +180,7 @@ function renderFavoriteList(list) {
     card.innerHTML = `
       <img class="my-post-thumb" src="${thumb}" alt="thumbnail" />
       <div class="my-post-body">
-        <h4 class="my-post-title">${title}</h4>
+        <h4 class="my-post-title">${escapeHtml(title)}</h4>
         <p class="my-post-sub">${address}</p>
         <p class="my-post-price">보증금 ${formatMoney(deposit)} / 월세 ${formatMoney(monthlyRent)}</p>
       </div>
@@ -440,7 +440,7 @@ async function loadMyRooms() {
 
 function renderMyRoomCard(room) {
   const roomId = room.roomId ?? room.room_id;
-  const title = room.title ?? "-";
+  const title = room.roomTitle ?? room.room_title ?? room.title ?? "-";
   const address = room.address ?? "-";
   const status = room.status ?? "OPEN";
   const thumb = room.thumbnailUrl ?? room.thumbnail_url ?? "/resources/img/room/default-room.jpg";

--- a/src/main/webapp/resources/js/member/profileView.js
+++ b/src/main/webapp/resources/js/member/profileView.js
@@ -126,7 +126,7 @@ function initTabs() {
 
 function renderMemberRoomCard(room) {
   const roomId = pick(room, ["roomId", "room_id"]);
-  const title = pick(room, ["title"]) ?? "방 제목";
+  const title = pick(room, ["roomTitle", "room_title"]) ?? "방 제목";
   const address = pick(room, ["address"]) ?? "";
   const thumb =
     pick(room, ["thumbnailUrl", "thumbnail_url", "thumbnail"]) ||

--- a/src/main/webapp/resources/js/room/roomCreate.js
+++ b/src/main/webapp/resources/js/room/roomCreate.js
@@ -21,7 +21,7 @@ const TEXT_KEY = makeDraftKey({ app: APP, page: TEXT_PAGE, userScope: USER_SCOPE
 const IMG_KEY  = makeDraftKey({ app: APP, page: IMG_PAGE, userScope: USER_SCOPE, version: VERSION });
 
 function validate(payload) {
-  if (!payload.title) return "제목은 필수입니다.";
+  if (!payload.room_title) return "제목은 필수입니다.";
   if (!payload.content) return "상세 설명은 필수입니다.";
   if (!payload.address) return "주소는 필수입니다.";
   if (payload.room_type_id == null || Number.isNaN(payload.room_type_id)) return "방 타입은 필수입니다.";
@@ -52,7 +52,7 @@ function debounce(fn, wait = 250) {
 function buildTextDraft() {
   // 주소 + 상세주소는 "분리 값"으로 저장(복구 UX 좋게)
   return {
-    title: v("title"),
+    room_title: v("roomTitle"),
     content: v("content"),
 
     room_type_id: v("roomTypeId"),
@@ -108,7 +108,7 @@ function applyTextDraft(draft) {
     el.value = (val ?? "");
   };
 
-  setVal("title", draft.title);
+  setVal("roomTitle", draft.room_title);
   setVal("content", draft.content);
 
   setVal("roomTypeId", draft.room_type_id);
@@ -130,7 +130,7 @@ const saveTextDraftDebounced = debounce(saveTextDraft, 250);
 function setupDraftAutoSave() {
   // 네 form DOM id 기준
   const ids = [
-    "title",
+    "roomTitle",
     "content",
     "roomTypeId",
     "monthlyRent",
@@ -384,7 +384,7 @@ async function submitRoom(e) {
   const fullAddress = addrDetail ? `${addr} ${addrDetail}` : addr;
 
   const payload = {
-    title: v("title"),
+    room_title: v("roomTitle"),
     content: v("content"),
 
     room_type_id: n("roomTypeId"),

--- a/src/main/webapp/resources/js/room/roomDetail.js
+++ b/src/main/webapp/resources/js/room/roomDetail.js
@@ -272,6 +272,10 @@ function bindActionsOnce(roomId) {
     viewProfileBtn.addEventListener("click", () => {
       const ownerId = currentRoom?.ownerId ?? currentRoom?.owner_id ?? null;
       if (!ownerId) return;
+      if (isOwnerOfRoom(currentRoom)) {
+        location.href = "/members/mypage";
+        return;
+      }
       location.href = `/members/${ownerId}`;
     });
   }
@@ -367,6 +371,10 @@ async function loadRoomDetail(roomId) {
 // ===================== Render =====================
 
 function renderRoomDetail(room) {
+  const titleEl = document.querySelector(".room-detail-title");
+  if (titleEl) {
+    titleEl.textContent = room.roomTitle ?? room.room_title ?? room.title ?? "방 제목";
+  }
   const imageUrls = room.imageUrls ?? room.image_urls ?? [];
   const validUrls = imageUrls.filter(Boolean);
   const mainImgEl = document.getElementById("room-main-image");

--- a/src/main/webapp/resources/js/room/roomEdit.js
+++ b/src/main/webapp/resources/js/room/roomEdit.js
@@ -121,7 +121,7 @@ async function loadRoomDetailAndFill(roomId, existingImageUrls) {
   const data = await res.json();
 
   // 값 채우기
-  setValue("title", data.title ?? data.roomTitle ?? "");
+  setValue("roomTitle", data.roomTitle ?? data.room_title ?? data.title ?? "");
   setValue("content", data.content ?? data.roomContent ?? "");
   setValue("address", data.address ?? "");
   setValue("legalDong", data.legalDong ?? data.legal_dong ?? "");
@@ -290,7 +290,7 @@ function bindSubmit(roomId, existingImageUrls, newImageUrls, tempFileIds) {
     const validTempFileIds = tempFileIds.filter((x) => Number.isFinite(Number(x)));
 
     const payload = {
-      title: v("title"),
+      room_title: v("roomTitle"),
       content: v("content"),
 
       room_type_id: n("roomTypeId"),
@@ -310,7 +310,7 @@ function bindSubmit(roomId, existingImageUrls, newImageUrls, tempFileIds) {
     };
 
     // 최소 검증
-    if (!payload.title || !payload.content || !payload.address || !payload.room_type_id) {
+    if (!payload.room_title  || !payload.content || !payload.address || !payload.room_type_id) {
       alert("필수 항목(제목/설명/주소/방타입)을 입력해 주세요.");
       return;
     }

--- a/src/main/webapp/resources/js/room/roomMap.js
+++ b/src/main/webapp/resources/js/room/roomMap.js
@@ -270,8 +270,10 @@ function renderRoomDetail(room) {
       imgEl.style.display = "none";
     }
   }
+  const roomTitle = room.roomTitle ?? room.room_title;
+
   document.getElementById("room-title").innerText =
-    room.title || "제목 없음";
+    roomTitle || "제목 없음";
   document.getElementById("room-address").innerText =
     room.address || "";
 
@@ -404,7 +406,7 @@ function renderNearbyRooms(selectedRoom) {
 
   candidates.forEach(({ room }) => {
     const id = room.roomId ?? room.room_id;
-    const title = room.title ?? room.room_title ?? "제목 없음";
+    const title = room.roomTitle ?? room.room_title ?? "제목 없음";
     const addr = room.address ?? "";
     const monthlyRent = room.monthlyRent ?? room.monthly_rent;
     const thumbnail = room.thumbnailUrl ?? room.thumbnail_url ?? "";


### PR DESCRIPTION
## 개요

방 제목 필드가 `title / roomTitle / room_title`로 혼용되어  
지도, 상세, 수정, 마이페이지, 프로필 등 여러 화면에서  
제목이 표시되지 않거나 수정 페이지에서 불러와지지 않는 문제가 발생했습니다.

본 작업에서는 방 제목 네이밍을 `roomTitle` 기준으로 정리하여  
프론트–백엔드 간 데이터 정합성을 맞추고,  
상세 페이지에서 **프로필 보기 버튼의 이동 UX를 개선**했습니다.

---

## 주요 변경 사항

### 1. 방 제목 네이밍 정합성 수정

- 방 제목 필드를 `roomTitle` 기준으로 통일
- 프론트에서 `roomTitle / room_title / title` fallback 처리
- 수정 페이지 input id를 `roomTitle`로 변경하여 JS와 일치시킴
- 지도 / 상세 / 마이페이지 / 프로필 / 관심목록에서 제목 렌더링 누락 문제 해결

---

### 2. 방 수정 페이지 제목 로딩 오류 해결

- 수정 페이지 진입 시 기존 방 제목이 비어 있던 문제 수정
- HTML ↔ JS ↔ API 응답 필드명 불일치로 인한 버그 제거
- 수정 후 제목 정상 저장 및 재조회 확인

---

### 3. 상세 페이지 프로필 보기 UX 개선

- “프로필 보기” 버튼 클릭 시 사용자 상태에 따라 이동 경로 분기
  - 비로그인 사용자 → 로그인 유도
  - 내가 작성한 방 → `/members/mypage`
  - 다른 사용자의 방 → `/members/{memberId}`

---

## 변경 범위

### Frontend
- `roomEdit.jsp`, `roomEdit.js`
- `roomDetail.js`
- `profileView.js`
- 마이페이지 / 관심목록 / 목록 카드 렌더링 로직

### Backend
- 방 목록/지도 관련 DTO 및 필드 정합성 보완
- 방 제목 필드(`roomTitle`) 기준 데이터 전달

---

## 완료 기준 (Acceptance Criteria)

- [x] 지도 페이지에서 방 제목 정상 표시
- [x] 상세 페이지에서 방 제목 정상 표시
- [x] 방 수정 페이지에서 기존 제목 정상 로딩
- [x] 방 수정 후 제목 정상 저장
- [x] 마이페이지 / 프로필 / 관심목록 제목 정상 표시
- [x] 상세 페이지에서 프로필 보기 이동 분기 정상 동작

---

## 비고

- 방 제목 네이밍 혼용으로 발생하던 전반적인 렌더링 버그를 일괄 정리
- 프론트 단에서의 fallback 처리로 기존 API 응답과의 호환성 유지
- View / JS / API 간 책임 분리 구조 유지
