### PR TITLE
 feat: 관리자 회원 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/roommate/admin/controller/AdminRestController.java
+++ b/src/main/java/com/roommate/admin/controller/AdminRestController.java
@@ -1,7 +1,23 @@
 package com.roommate.admin.controller;
 
+import com.roommate.admin.dto.AdminMemberListResponse;
+import com.roommate.admin.service.AdminMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
 public class AdminRestController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping("/members")
+    public AdminMemberListResponse getMembers(@RequestParam(defaultValue = "1") int page,
+                                              @RequestParam(defaultValue = "20") int size) {
+        return adminMemberService.getMembers(page, size);
+    }
 }

--- a/src/main/java/com/roommate/admin/dto/AdminMemberListItemResponse.java
+++ b/src/main/java/com/roommate/admin/dto/AdminMemberListItemResponse.java
@@ -1,0 +1,22 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.roommate.domain.member.entity.MemberRoleEnum;
+import com.roommate.domain.member.entity.MemberStatusEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class AdminMemberListItemResponse {
+    private Long memberId;
+    private String email;
+    private String name;
+    private MemberRoleEnum role;
+    private MemberStatusEnum status;
+    private LocalDateTime memberCreatedAt;
+}

--- a/src/main/java/com/roommate/admin/dto/AdminMemberListResponse.java
+++ b/src/main/java/com/roommate/admin/dto/AdminMemberListResponse.java
@@ -1,0 +1,20 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class AdminMemberListResponse {
+    private List<AdminMemberListItemResponse> items;
+    private int page;
+    private int size;
+    private long totalCount;
+    private int totalPages;
+    private boolean hasNext;
+}

--- a/src/main/java/com/roommate/admin/service/AdminMemberService.java
+++ b/src/main/java/com/roommate/admin/service/AdminMemberService.java
@@ -1,0 +1,7 @@
+package com.roommate.admin.service;
+
+import com.roommate.admin.dto.AdminMemberListResponse;
+
+public interface AdminMemberService {
+    AdminMemberListResponse getMembers(int page, int size);
+}

--- a/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
@@ -1,0 +1,30 @@
+package com.roommate.admin.service;
+
+import com.roommate.admin.dto.AdminMemberListItemResponse;
+import com.roommate.admin.dto.AdminMemberListResponse;
+import com.roommate.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberServiceImpl implements AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public AdminMemberListResponse getMembers(int page, int size) {
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.max(size, 1);
+        int offset = (safePage - 1) * safeSize;
+
+        long totalCount = memberRepository.countMembersForAdmin();
+        List<AdminMemberListItemResponse> items = memberRepository.findMembersForAdmin(safeSize, offset);
+        int totalPages = totalCount == 0 ? 0 : (int) Math.ceil((double) totalCount / safeSize);
+        boolean hasNext = safePage < totalPages;
+
+        return new AdminMemberListResponse(items, safePage, safeSize, totalCount, totalPages, hasNext);
+    }
+}

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.roommate.domain.member.repository;
 
 import com.roommate.domain.member.entity.MemberEntity;
+import com.roommate.admin.dto.AdminMemberListItemResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -29,5 +31,8 @@ public interface MemberRepository {
 
     void updatePhotoUrl(@Param("memberId") Long memberId, @Param("photoUrl") String photoUrl);
 
+    long countMembersForAdmin();
+
+    List<AdminMemberListItemResponse> findMembersForAdmin(@Param("limit") int limit, @Param("offset") int offset);
 
 }

--- a/src/main/resources/mapper/member/Member.xml
+++ b/src/main/resources/mapper/member/Member.xml
@@ -131,4 +131,23 @@
         WHERE member_id = #{memberId}
         AND deleted = 0
     </update>
+
+    <select id="countMembersForAdmin" resultType="long">
+        SELECT COUNT(*)
+        FROM members
+    </select>
+
+    <select id="findMembersForAdmin" resultType="com.roommate.admin.dto.AdminMemberListItemResponse">
+        SELECT
+            member_id AS memberId,
+            email,
+            name,
+            role,
+            status,
+            member_created_at AS memberCreatedAt
+        FROM members
+        ORDER BY member_created_at DESC, member_id DESC
+        LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
 </mapper>


### PR DESCRIPTION
 ## 개요                                                                                                             
  관리자 페이지의 후속 기능으로, 관리자만 조회할 수 있는 회원 목록 API를 추가했습니다.
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 관리자 회원 목록 조회 API 추가                                                                                    
    - `GET /api/admin/members`                                                                                        
  - 회원 목록 응답 DTO 추가                                                                                           
  - 페이지네이션 메타데이터를 포함한 응답 구조 추가                                                                   
  - 관리자 회원 목록 조회용 서비스 추가                                                                               
  - 회원 수 조회 및 목록 조회용 MyBatis 쿼리 추가                                                                     
                                                                                                                                                                                                                                     
  ## 구현 내용                                                                                                        
                                                                                                                      
  - 목록 응답에 다음 필드를 포함                                                                                      
      - 회원 ID                                                                                                       
      - 이메일                                                                                                        
      - 이름                                                                                                          
      - 권한                                                                                                          
      - 상태                                                                                                          
      - 가입일                                                                                                        
  - 향후 검색, 필터, 페이지네이션 확장을 고려해 items와 메타데이터를 분리한 응답 구조 사용                            
  - 현재는 page, size 기반 페이지네이션만 먼저 지원                                                                   
  - /api/admin/** 기존 보안 규칙을 그대로 사용해 관리자만 접근 가능                                                   
                                                                                                                      
  ## 테스트                                                                                                           
                                                                                                                      
  - mvn -q -DskipTests compile                                                                                        
  - 관리자 계정으로 GET /api/admin/members?page=1&size=2 요청 시 200                                                  
  - 일반 사용자 계정으로 동일 API 요청 시 403                                                                         
  - 응답에 페이지 메타데이터와 회원 기본 정보 포함 확인

  ## 관련 이슈                                                                                                        
                                                                                                                      
  - closes #44  
 