### PR TITLE
feat: 관리자 회원 목록 화면 추가

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -14,11 +14,33 @@
   <main class="admin-page">
     <section class="admin-heading">
       <p>관리자</p>
-      <h1>대시보드</h1>
+      <h1>회원 관리</h1>
     </section>
 
-    <section class="admin-placeholder" aria-label="향후 관리자 기능">
-      <h2>표시할 관리 항목이 없습니다.</h2>
+    <section class="member-summary" aria-label="회원 목록 요약">
+      <span id="adminMemberCount">회원을 불러오는 중입니다.</span>
+    </section>
+
+    <section class="member-table-section" aria-label="회원 목록">
+      <div class="member-table-wrap">
+        <table class="member-table">
+          <thead>
+            <tr>
+              <th scope="col">회원 ID</th>
+              <th scope="col">이메일</th>
+              <th scope="col">이름</th>
+              <th scope="col">권한</th>
+              <th scope="col">상태</th>
+              <th scope="col">가입일</th>
+            </tr>
+          </thead>
+          <tbody id="adminMemberTableBody">
+            <tr class="member-table-empty">
+              <td colspan="6">회원 목록을 불러오는 중입니다.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </main>
 
@@ -26,6 +48,7 @@
     window.contextPath = "${pageContext.request.contextPath}";
   </script>
   <script type="module" src="${pageContext.request.contextPath}/resources/js/admin/adminGuard.js"></script>
+  <script type="module" src="${pageContext.request.contextPath}/resources/js/admin/memberList.js"></script>
   <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -29,18 +29,87 @@ body {
   letter-spacing: 0;
 }
 
-.admin-placeholder {
+.member-summary {
   margin-top: 32px;
-  padding: 28px;
+  color: #475467;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.member-table-section {
+  margin-top: 18px;
+}
+
+.member-table-wrap {
+  overflow-x: auto;
   border: 1px solid #eaecf0;
   border-radius: 8px;
   background: #fff;
 }
 
-.admin-placeholder h2 {
-  margin: 0;
-  font-size: 22px;
-  letter-spacing: 0;
+.member-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.member-table th,
+.member-table td {
+  padding: 16px 18px;
+  border-bottom: 1px solid #eaecf0;
+  text-align: left;
+  font-size: 14px;
+}
+
+.member-table th {
+  color: #475467;
+  background: #f9fafb;
+  font-weight: 700;
+}
+
+.member-table td {
+  color: #101828;
+}
+
+.member-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.member-table-empty td {
+  height: 120px;
+  color: #667085;
+  text-align: center;
+}
+
+.member-role,
+.member-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.member-role {
+  background: #eef4ff;
+  color: #3538cd;
+}
+
+.member-status-active {
+  background: #ecfdf3;
+  color: #027a48;
+}
+
+.member-status-banned {
+  background: #fef3f2;
+  color: #b42318;
+}
+
+.member-status-deleted {
+  background: #f2f4f7;
+  color: #475467;
 }
 
 @media (max-width: 720px) {

--- a/src/main/webapp/resources/js/admin/memberList.js
+++ b/src/main/webapp/resources/js/admin/memberList.js
@@ -1,0 +1,89 @@
+import { apiRequest } from "../common/apiClient.js";
+
+const contextPath = window.contextPath || "";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  await loadMembers();
+});
+
+async function loadMembers() {
+  const count = document.getElementById("adminMemberCount");
+  const tableBody = document.getElementById("adminMemberTableBody");
+  if (!count || !tableBody) return;
+
+  try {
+    const response = await apiRequest(`${contextPath}/api/admin/members?page=1&size=20`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw new Error(`admin member api failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const members = Array.isArray(data.items) ? data.items : [];
+    count.textContent = `전체 회원 ${formatNumber(data.total_count || 0)}명`;
+
+    if (members.length === 0) {
+      tableBody.innerHTML = `
+        <tr class="member-table-empty">
+          <td colspan="6">표시할 회원이 없습니다.</td>
+        </tr>
+      `;
+      return;
+    }
+
+    tableBody.innerHTML = members.map(renderMemberRow).join("");
+  } catch (error) {
+    console.error(error);
+    count.textContent = "회원 목록을 불러오지 못했습니다.";
+    tableBody.innerHTML = `
+      <tr class="member-table-empty">
+        <td colspan="6">회원 목록을 불러오지 못했습니다.</td>
+      </tr>
+    `;
+  }
+}
+
+function renderMemberRow(member) {
+  const role = member.role || "-";
+  const status = member.status || "-";
+
+  return `
+    <tr>
+      <td>${escapeHtml(member.member_id)}</td>
+      <td>${escapeHtml(member.email)}</td>
+      <td>${escapeHtml(member.name)}</td>
+      <td><span class="member-role">${escapeHtml(role)}</span></td>
+      <td><span class="member-status ${statusClass(status)}">${escapeHtml(status)}</span></td>
+      <td>${escapeHtml(formatDate(member.member_created_at))}</td>
+    </tr>
+  `;
+}
+
+function statusClass(status) {
+  if (status === "ACTIVE") return "member-status-active";
+  if (status === "BANNED") return "member-status-banned";
+  if (status === "DELETED") return "member-status-deleted";
+  return "";
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleDateString("ko-KR");
+}
+
+function formatNumber(value) {
+  return Number(value || 0).toLocaleString("ko-KR");
+}
+
+function escapeHtml(value) {
+  return String(value ?? "-")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}


### PR DESCRIPTION
## 개요                                                                                                             
  관리자 페이지에서 회원 목록을 확인할 수 있도록 기본 테이블 화면을 추가했습니다.                                     
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 관리자 메인 화면을 회원 관리 화면으로 확장                                                                        
  - 회원 수 요약 영역 추가                                                                                            
  - 회원 목록 기본 테이블 레이아웃 추가                                                                               
  - 회원 목록 API 연동                                                                                                
    - `GET /api/admin/members`                                                                                        
  - 로딩, 빈 상태, 오류 상태 UI 추가                                                                                  
  - 회원 권한과 상태를 구분할 수 있는 배지 스타일 추가                                                                
 
  ## 구현 내용                                                                                                        
  - 관리자 화면에서 다음 정보를 표시                                                                                  
    - 회원 ID                                                                                                         
    - 이메일                                                                                                          
    - 이름                                                                                                            
    - 권한                                                                                                            
    - 상태                                                                                                            
    - 가입일                                                                                                          
  - 기존 Issue 44의 회원 목록 API 응답을 사용해 화면 렌더링                                                           
  - 현재는 첫 페이지 20건을 조회                                                                                      
  - 검색, 필터, 페이지 이동 UI는 후속 이슈에서 확장 가능하도록 화면 구조를 단순하게 유지                              
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - Tomcat 재시작 후 `/admin` 페이지 응답 `200` 확인                                                                  
  - 관리자 계정으로 접속 시 회원 목록 테이블 표시 확인                                                                
  - 회원 목록 API와 화면 연결 확인                                                                                    
  - 빈 상태 및 오류 상태 렌더링 로직 추가 확인                                                                        
                                                                                                                      
  ## 관련 이슈                                                                                                        
  - closes #46                     