### PR TITLE
feat: 관리자 회원 정지 및 해제 기능 추가

### DIFF
--- a/src/main/java/com/roommate/admin/controller/AdminRestController.java
+++ b/src/main/java/com/roommate/admin/controller/AdminRestController.java
@@ -1,10 +1,17 @@
 package com.roommate.admin.controller;
 
+import com.roommate.admin.dto.AdminMemberListItemResponse;
 import com.roommate.admin.dto.AdminMemberListResponse;
+import com.roommate.admin.dto.AdminMemberStatusUpdateRequest;
 import com.roommate.admin.service.AdminMemberService;
+import com.roommate.common.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +26,12 @@ public class AdminRestController {
     public AdminMemberListResponse getMembers(@RequestParam(defaultValue = "1") int page,
                                               @RequestParam(defaultValue = "20") int size) {
         return adminMemberService.getMembers(page, size);
+    }
+
+    @PatchMapping("/members/{memberId}/status")
+    public AdminMemberListItemResponse updateMemberStatus(@PathVariable Long memberId,
+                                                          @RequestBody AdminMemberStatusUpdateRequest request,
+                                                          @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return adminMemberService.updateMemberStatus(memberId, request.getStatus(), userDetails.getMemberId());
     }
 }

--- a/src/main/java/com/roommate/admin/dto/AdminMemberStatusUpdateRequest.java
+++ b/src/main/java/com/roommate/admin/dto/AdminMemberStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.roommate.domain.member.entity.MemberStatusEnum;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminMemberStatusUpdateRequest {
+    private MemberStatusEnum status;
+}

--- a/src/main/java/com/roommate/admin/service/AdminMemberService.java
+++ b/src/main/java/com/roommate/admin/service/AdminMemberService.java
@@ -1,7 +1,11 @@
 package com.roommate.admin.service;
 
+import com.roommate.admin.dto.AdminMemberListItemResponse;
 import com.roommate.admin.dto.AdminMemberListResponse;
+import com.roommate.domain.member.entity.MemberStatusEnum;
 
 public interface AdminMemberService {
     AdminMemberListResponse getMembers(int page, int size);
+
+    AdminMemberListItemResponse updateMemberStatus(Long memberId, MemberStatusEnum status, Long currentAdminId);
 }

--- a/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
@@ -2,6 +2,11 @@ package com.roommate.admin.service;
 
 import com.roommate.admin.dto.AdminMemberListItemResponse;
 import com.roommate.admin.dto.AdminMemberListResponse;
+import com.roommate.common.exception.ApiException;
+import com.roommate.common.exception.ErrorCode;
+import com.roommate.domain.member.entity.MemberEntity;
+import com.roommate.domain.member.entity.MemberRoleEnum;
+import com.roommate.domain.member.entity.MemberStatusEnum;
 import com.roommate.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,5 +31,40 @@ public class AdminMemberServiceImpl implements AdminMemberService {
         boolean hasNext = safePage < totalPages;
 
         return new AdminMemberListResponse(items, safePage, safeSize, totalCount, totalPages, hasNext);
+    }
+
+    @Override
+    public AdminMemberListItemResponse updateMemberStatus(Long memberId, MemberStatusEnum status, Long currentAdminId) {
+        if (status != MemberStatusEnum.ACTIVE && status != MemberStatusEnum.BANNED) {
+            throw new ApiException(ErrorCode.ADMIN_MEMBER_STATUS_INVALID);
+        }
+
+        MemberEntity member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_MEMBER_NOT_FOUND));
+
+        if (member.getMemberId().equals(currentAdminId)) {
+            throw new ApiException(ErrorCode.ADMIN_SELF_STATUS_CHANGE_NOT_ALLOWED);
+        }
+        if (member.getRole() != MemberRoleEnum.USER) {
+            throw new ApiException(ErrorCode.ADMIN_TARGET_ADMIN_NOT_ALLOWED);
+        }
+        if (member.getStatus() == MemberStatusEnum.DELETED || member.getDeleted() == 1) {
+            throw new ApiException(ErrorCode.ADMIN_MEMBER_STATUS_INVALID);
+        }
+
+        int updatedCount = memberRepository.updateMemberStatusForAdmin(memberId, status);
+        if (updatedCount != 1) {
+            throw new ApiException(ErrorCode.ADMIN_MEMBER_BAN_FAILED);
+        }
+
+        member.setStatus(status);
+        return new AdminMemberListItemResponse(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getName(),
+                member.getRole(),
+                member.getStatus(),
+                member.getMemberCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/roommate/common/exception/ErrorCode.java
+++ b/src/main/java/com/roommate/common/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     ADMIN_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AD002", "관리 대상 회원이 존재하지 않습니다."),
     ADMIN_MEMBER_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AD003", "회원 삭제에 실패했습니다."),
     ADMIN_MEMBER_BAN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AD004", "회원 정지 처리에 실패했습니다."),
+    ADMIN_SELF_STATUS_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "AD005", "관리자는 본인 계정을 정지하거나 해제할 수 없습니다."),
+    ADMIN_TARGET_ADMIN_NOT_ALLOWED(HttpStatus.FORBIDDEN, "AD006", "다른 관리자 계정은 정지하거나 해제할 수 없습니다."),
+    ADMIN_MEMBER_STATUS_INVALID(HttpStatus.BAD_REQUEST, "AD007", "변경할 수 없는 회원 상태입니다."),
 
     // ===== MEMBER / 회원 관련 =====
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M001", "이미 사용중인 이메일입니다."),

--- a/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/roommate/domain/member/repository/MemberRepository.java
@@ -1,7 +1,8 @@
 package com.roommate.domain.member.repository;
 
-import com.roommate.domain.member.entity.MemberEntity;
 import com.roommate.admin.dto.AdminMemberListItemResponse;
+import com.roommate.domain.member.entity.MemberEntity;
+import com.roommate.domain.member.entity.MemberStatusEnum;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -34,5 +35,7 @@ public interface MemberRepository {
     long countMembersForAdmin();
 
     List<AdminMemberListItemResponse> findMembersForAdmin(@Param("limit") int limit, @Param("offset") int offset);
+
+    int updateMemberStatusForAdmin(@Param("memberId") Long memberId, @Param("status") MemberStatusEnum status);
 
 }

--- a/src/main/resources/mapper/member/Member.xml
+++ b/src/main/resources/mapper/member/Member.xml
@@ -150,4 +150,13 @@
         LIMIT #{limit}
         OFFSET #{offset}
     </select>
+
+    <update id="updateMemberStatusForAdmin">
+        UPDATE members
+        SET status = #{status},
+            banned_until = NULL,
+            member_updated_at = NOW()
+        WHERE member_id = #{memberId}
+        AND deleted = 0
+    </update>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -32,11 +32,12 @@
               <th scope="col">권한</th>
               <th scope="col">상태</th>
               <th scope="col">가입일</th>
+              <th scope="col">관리</th>
             </tr>
           </thead>
           <tbody id="adminMemberTableBody">
             <tr class="member-table-empty">
-              <td colspan="6">회원 목록을 불러오는 중입니다.</td>
+              <td colspan="7">회원 목록을 불러오는 중입니다.</td>
             </tr>
           </tbody>
         </table>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -112,6 +112,36 @@ body {
   color: #475467;
 }
 
+.member-action-btn {
+  min-width: 64px;
+  height: 34px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #101828;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.member-action-btn:hover {
+  background: #f9fafb;
+}
+
+.member-action-btn[data-next-status="BANNED"] {
+  border-color: #fecdca;
+  color: #b42318;
+}
+
+.member-action-btn:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.member-action-empty {
+  color: #98a2b3;
+}
+
 @media (max-width: 720px) {
   .admin-page {
     padding: 32px 18px 72px;

--- a/src/main/webapp/resources/js/admin/memberList.js
+++ b/src/main/webapp/resources/js/admin/memberList.js
@@ -27,19 +27,20 @@ async function loadMembers() {
     if (members.length === 0) {
       tableBody.innerHTML = `
         <tr class="member-table-empty">
-          <td colspan="6">표시할 회원이 없습니다.</td>
+          <td colspan="7">표시할 회원이 없습니다.</td>
         </tr>
       `;
       return;
     }
 
     tableBody.innerHTML = members.map(renderMemberRow).join("");
+    bindActionButtons(tableBody);
   } catch (error) {
     console.error(error);
     count.textContent = "회원 목록을 불러오지 못했습니다.";
     tableBody.innerHTML = `
       <tr class="member-table-empty">
-        <td colspan="6">회원 목록을 불러오지 못했습니다.</td>
+        <td colspan="7">회원 목록을 불러오지 못했습니다.</td>
       </tr>
     `;
   }
@@ -57,8 +58,67 @@ function renderMemberRow(member) {
       <td><span class="member-role">${escapeHtml(role)}</span></td>
       <td><span class="member-status ${statusClass(status)}">${escapeHtml(status)}</span></td>
       <td>${escapeHtml(formatDate(member.member_created_at))}</td>
+      <td>${renderActionCell(member)}</td>
     </tr>
   `;
+}
+
+function renderActionCell(member) {
+  if (member.role !== "USER") {
+    return '<span class="member-action-empty">-</span>';
+  }
+
+  const nextStatus = member.status === "BANNED" ? "ACTIVE" : "BANNED";
+  const label = nextStatus === "BANNED" ? "정지" : "해제";
+  return `
+    <button
+      type="button"
+      class="member-action-btn"
+      data-member-id="${escapeHtml(member.member_id)}"
+      data-next-status="${escapeHtml(nextStatus)}">
+      ${label}
+    </button>
+  `;
+}
+
+function bindActionButtons(container) {
+  container.querySelectorAll(".member-action-btn").forEach((button) => {
+    button.addEventListener("click", async () => {
+      await updateMemberStatus(button);
+    });
+  });
+}
+
+async function updateMemberStatus(button) {
+  const memberId = button.dataset.memberId;
+  const nextStatus = button.dataset.nextStatus;
+  if (!memberId || !nextStatus) return;
+
+  const ok = confirm(nextStatus === "BANNED" ? "이 회원을 정지하시겠습니까?" : "이 회원의 정지를 해제하시겠습니까?");
+  if (!ok) return;
+
+  button.disabled = true;
+
+  try {
+    const response = await apiRequest(`${contextPath}/api/admin/members/${encodeURIComponent(memberId)}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: nextStatus }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`admin member status api failed: ${response.status}`);
+    }
+
+    const updatedMember = await response.json();
+    const row = button.closest("tr");
+    if (!row) return;
+    row.outerHTML = renderMemberRow(updatedMember);
+    bindActionButtons(document.getElementById("adminMemberTableBody"));
+  } catch (error) {
+    console.error(error);
+    alert("회원 상태를 변경하지 못했습니다.");
+    button.disabled = false;
+  }
 }
 
 function statusClass(status) {


### PR DESCRIPTION
## 개요                                                                                                             
  관리자 회원 목록에서 일반 회원을 정지하거나 정지 해제할 수 있는 기능을 추가했습니다.                                
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 관리자 회원 상태 변경 API 추가                                                                                    
    - `PATCH /api/admin/members/{memberId}/status`                                                                    
  - 관리자 회원 상태 변경 요청 DTO 추가                                                                               
  - 일반 회원 정지/해제 서비스 로직 추가                                                                              
  - 회원 목록 화면에 `관리` 열과 상태 변경 버튼 추가                                                                  
  - 처리 성공 시 해당 행의 상태와 버튼을 즉시 갱신하도록 UI 개선                                                      
  - 상태 변경 정책에 맞는 예외 코드 추가                                                                              
                                                                                                                      
  ## 정책                                                                                                             
  - 정지/해제 대상은 `USER` 계정만 허용                                                                               
  - 관리자는 본인 계정을 정지하거나 해제할 수 없음                                                                    
  - 다른 `ADMIN` 계정도 정지하거나 해제할 수 없음                                                                     
  - 삭제된 회원은 상태 변경 대상에서 제외                                                                             
                                                                                                                      
  ## 구현 내용                                                                                                        
  - 일반 회원이 `ACTIVE` 상태이면 `정지` 버튼 표시                                                                    
  - 일반 회원이 `BANNED` 상태이면 `해제` 버튼 표시                                                                    
  - 관리자 계정은 액션 버튼 대신 `-` 표시                                                                             
  - 상태 변경 성공 시 새 응답값으로 해당 테이블 행을 즉시 다시 렌더링                                                 
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - 일반 회원 정지 요청 시 `BANNED` 변경 확인                                                                         
  - 일반 회원 해제 요청 시 `ACTIVE` 변경 확인                                                                         
  - 본인 관리자 계정 상태 변경 요청 시 `403`                                                                          
  - 다른 관리자 계정 상태 변경 요청 시 `403`                                                                          
                                                                                                                      
  ## 관련 이슈                                                                                                        
  - closes #48                                           