### PR TITLE
feat: 관리자 신고 목록 화면 추가 

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -14,16 +14,19 @@
   <main class="admin-page">
     <section class="admin-heading">
       <p>관리자</p>
-      <h1>회원 관리</h1>
+      <h1>운영 관리</h1>
     </section>
 
-    <section class="member-summary" aria-label="회원 목록 요약">
-      <span id="adminMemberCount">회원을 불러오는 중입니다.</span>
-    </section>
+    <section class="admin-section" aria-label="회원 목록">
+      <div class="section-header">
+        <div>
+          <h2>회원 관리</h2>
+          <p id="adminMemberCount">회원을 불러오는 중입니다.</p>
+        </div>
+      </div>
 
-    <section class="member-table-section" aria-label="회원 목록">
-      <div class="member-table-wrap">
-        <table class="member-table">
+      <div class="data-table-wrap">
+        <table class="data-table member-table">
           <thead>
             <tr>
               <th scope="col">회원 ID</th>
@@ -36,8 +39,43 @@
             </tr>
           </thead>
           <tbody id="adminMemberTableBody">
-            <tr class="member-table-empty">
+            <tr class="data-table-empty">
               <td colspan="7">회원 목록을 불러오는 중입니다.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="admin-section" aria-label="신고 목록">
+      <div class="section-header section-header-reports">
+        <div>
+          <h2>신고 관리</h2>
+          <p id="adminReportCount">신고를 불러오는 중입니다.</p>
+        </div>
+
+        <div class="report-filter" role="group" aria-label="신고 상태 필터">
+          <button type="button" class="report-filter-btn is-active" data-status="ALL">전체</button>
+          <button type="button" class="report-filter-btn" data-status="PENDING">대기</button>
+          <button type="button" class="report-filter-btn" data-status="RESOLVED">처리완료</button>
+        </div>
+      </div>
+
+      <div class="data-table-wrap">
+        <table class="data-table report-table">
+          <thead>
+            <tr>
+              <th scope="col">신고 ID</th>
+              <th scope="col">신고 대상</th>
+              <th scope="col">신고자</th>
+              <th scope="col">사유</th>
+              <th scope="col">상태</th>
+              <th scope="col">생성일</th>
+            </tr>
+          </thead>
+          <tbody id="adminReportTableBody">
+            <tr class="data-table-empty">
+              <td colspan="6">신고 목록을 불러오는 중입니다.</td>
             </tr>
           </tbody>
         </table>
@@ -50,6 +88,7 @@
   </script>
   <script type="module" src="${pageContext.request.contextPath}/resources/js/admin/adminGuard.js"></script>
   <script type="module" src="${pageContext.request.contextPath}/resources/js/admin/memberList.js"></script>
+  <script type="module" src="${pageContext.request.contextPath}/resources/js/admin/reportList.js"></script>
   <script type="module" src="${pageContext.request.contextPath}/resources/js/auth/login.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -29,60 +29,77 @@ body {
   letter-spacing: 0;
 }
 
-.member-summary {
-  margin-top: 32px;
+.admin-section {
+  margin-top: 36px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.section-header p {
+  margin: 8px 0 0;
   color: #475467;
   font-size: 14px;
   font-weight: 700;
 }
 
-.member-table-section {
-  margin-top: 18px;
-}
-
-.member-table-wrap {
+.data-table-wrap {
   overflow-x: auto;
   border: 1px solid #eaecf0;
   border-radius: 8px;
   background: #fff;
 }
 
-.member-table {
+.data-table {
   width: 100%;
   min-width: 760px;
   border-collapse: collapse;
 }
 
-.member-table th,
-.member-table td {
+.data-table th,
+.data-table td {
   padding: 16px 18px;
   border-bottom: 1px solid #eaecf0;
   text-align: left;
   font-size: 14px;
 }
 
-.member-table th {
+.data-table th {
   color: #475467;
   background: #f9fafb;
   font-weight: 700;
 }
 
-.member-table td {
+.data-table td {
   color: #101828;
+  vertical-align: top;
 }
 
-.member-table tbody tr:last-child td {
+.data-table tbody tr:last-child td {
   border-bottom: 0;
 }
 
-.member-table-empty td {
+.data-table-empty td {
   height: 120px;
   color: #667085;
   text-align: center;
+  vertical-align: middle;
 }
 
 .member-role,
-.member-status {
+.member-status,
+.report-status {
   display: inline-flex;
   align-items: center;
   min-height: 28px;
@@ -142,6 +159,57 @@ body {
   color: #98a2b3;
 }
 
+.report-filter {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px;
+  border: 1px solid #d0d5dd;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.report-filter-btn {
+  min-width: 72px;
+  height: 34px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: #475467;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.report-filter-btn.is-active {
+  background: #101828;
+  color: #fff;
+}
+
+.report-party {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.report-party strong {
+  font-size: 14px;
+}
+
+.report-party span,
+.report-reason {
+  color: #667085;
+}
+
+.report-status-pending {
+  background: #fffaeb;
+  color: #b54708;
+}
+
+.report-status-resolved {
+  background: #ecfdf3;
+  color: #027a48;
+}
+
 @media (max-width: 720px) {
   .admin-page {
     padding: 32px 18px 72px;
@@ -149,5 +217,11 @@ body {
 
   .admin-heading h1 {
     font-size: 30px;
+  }
+
+  .section-header,
+  .section-header-reports {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/src/main/webapp/resources/js/admin/reportList.js
+++ b/src/main/webapp/resources/js/admin/reportList.js
@@ -1,0 +1,131 @@
+import { apiRequest } from "../common/apiClient.js";
+
+const contextPath = window.contextPath || "";
+let reports = [];
+let activeStatus = "ALL";
+
+document.addEventListener("DOMContentLoaded", async () => {
+  bindFilterButtons();
+  await loadReports();
+});
+
+async function loadReports() {
+  const count = document.getElementById("adminReportCount");
+  const tableBody = document.getElementById("adminReportTableBody");
+  if (!count || !tableBody) return;
+
+  try {
+    const response = await apiRequest(`${contextPath}/api/admin/reports?page=1&size=20`, {
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      throw new Error(`admin report api failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    reports = Array.isArray(data.items) ? data.items : [];
+    count.textContent = `전체 신고 ${formatNumber(data.total_count || 0)}건`;
+    renderReports();
+  } catch (error) {
+    console.error(error);
+    count.textContent = "신고 목록을 불러오지 못했습니다.";
+    tableBody.innerHTML = `
+      <tr class="data-table-empty">
+        <td colspan="6">신고 목록을 불러오지 못했습니다.</td>
+      </tr>
+    `;
+  }
+}
+
+function bindFilterButtons() {
+  document.querySelectorAll(".report-filter-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      activeStatus = button.dataset.status || "ALL";
+      document.querySelectorAll(".report-filter-btn").forEach((item) => {
+        item.classList.toggle("is-active", item === button);
+      });
+      renderReports();
+    });
+  });
+}
+
+function renderReports() {
+  const tableBody = document.getElementById("adminReportTableBody");
+  if (!tableBody) return;
+
+  const visibleReports = activeStatus === "ALL"
+    ? reports
+    : reports.filter((report) => report.status === activeStatus);
+
+  if (visibleReports.length === 0) {
+    tableBody.innerHTML = `
+      <tr class="data-table-empty">
+        <td colspan="6">${emptyMessage()}</td>
+      </tr>
+    `;
+    return;
+  }
+
+  tableBody.innerHTML = visibleReports.map(renderReportRow).join("");
+}
+
+function renderReportRow(report) {
+  return `
+    <tr>
+      <td>${escapeHtml(report.report_id)}</td>
+      <td>${renderParty(report.target_member_name, report.target_member_email)}</td>
+      <td>${renderParty(report.reporter_name, report.reporter_email)}</td>
+      <td class="report-reason">${escapeHtml(report.reason)}</td>
+      <td><span class="report-status ${statusClass(report.status)}">${escapeHtml(statusLabel(report.status))}</span></td>
+      <td>${escapeHtml(formatDate(report.report_created_at))}</td>
+    </tr>
+  `;
+}
+
+function renderParty(name, email) {
+  return `
+    <div class="report-party">
+      <strong>${escapeHtml(name)}</strong>
+      <span>${escapeHtml(email)}</span>
+    </div>
+  `;
+}
+
+function emptyMessage() {
+  if (activeStatus === "PENDING") return "대기 중인 신고가 없습니다.";
+  if (activeStatus === "RESOLVED") return "처리 완료된 신고가 없습니다.";
+  return "표시할 신고가 없습니다.";
+}
+
+function statusClass(status) {
+  if (status === "PENDING") return "report-status-pending";
+  if (status === "RESOLVED") return "report-status-resolved";
+  return "";
+}
+
+function statusLabel(status) {
+  if (status === "PENDING") return "대기";
+  if (status === "RESOLVED") return "처리완료";
+  return status || "-";
+}
+
+function formatDate(value) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleDateString("ko-KR");
+}
+
+function formatNumber(value) {
+  return Number(value || 0).toLocaleString("ko-KR");
+}
+
+function escapeHtml(value) {
+  return String(value ?? "-")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}


### PR DESCRIPTION
 ## 개요                                                                                                             
  관리자 페이지에서 신고 목록을 확인할 수 있도록 신고 관리 섹션을 추가했습니다.                                       
 
  ## 변경 사항                                                                                                        
  - 관리자 페이지에 신고 관리 섹션 추가                                                                               
  - 신고 목록 테이블 추가                                                                                             
  - 신고 처리 상태별 필터 UI 추가                                                                                     
    - 전체                                                                                                            
    - 대기                                                                                                            
    - 처리완료                                                                                                        
  - 기존 신고 목록 API 연동                                                                                           
    - `GET /api/admin/reports`                                                                                        
  - 상태별 빈 화면 문구 추가                                                                                          
  - 관리자 화면 구조를 회원 관리 / 신고 관리 섹션으로 확장                                                            
                                                                                                                      
  ## 구현 내용                                                                                                        
  - 신고 목록에 다음 정보를 표시                                                                                      
    - 신고 ID                                                                                                         
    - 신고 대상                                                                                                       
    - 신고자                                                                                                          
    - 신고 사유                                                                                                       
    - 처리 상태                                                                                                       
    - 생성일                                                                                                          
  - 신고 상태에 따라 배지 스타일 구분                                                                                 
    - `PENDING`                                                                                                       
    - `RESOLVED`                                                                                                      
  - 현재는 첫 페이지 20건을 조회하고, 화면에서 상태별 필터를 적용                                                     
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - `/admin` 페이지 응답 `200` 확인                                                                                   
  - 관리자 페이지 HTML에 신고 테이블 포함 확인                                                                        
  - `reportList.js` 정적 자산 응답 `200` 확인                                                                         
  - 상태 필터 로직 포함 확인                                                                                          
                                                                                                                      
  ## 관련 이슈                                                                                                        
  - closes #52 