### PR TITLE
feat: 관리자 신고 처리 기능 추가 

### DIFF
--- a/src/main/java/com/roommate/admin/controller/AdminRestController.java
+++ b/src/main/java/com/roommate/admin/controller/AdminRestController.java
@@ -4,6 +4,8 @@ import com.roommate.admin.dto.AdminMemberListItemResponse;
 import com.roommate.admin.dto.AdminMemberListResponse;
 import com.roommate.admin.dto.AdminMemberStatusUpdateRequest;
 import com.roommate.admin.dto.AdminReportListResponse;
+import com.roommate.admin.dto.AdminReportListItemResponse;
+import com.roommate.admin.dto.AdminReportStatusUpdateRequest;
 import com.roommate.admin.service.AdminMemberService;
 import com.roommate.admin.service.AdminReportService;
 import com.roommate.common.security.UserDetailsImpl;
@@ -42,5 +44,11 @@ public class AdminRestController {
     public AdminReportListResponse getReports(@RequestParam(defaultValue = "1") int page,
                                               @RequestParam(defaultValue = "20") int size) {
         return adminReportService.getReports(page, size);
+    }
+
+    @PatchMapping("/reports/{reportId}/status")
+    public AdminReportListItemResponse updateReportStatus(@PathVariable Long reportId,
+                                                          @RequestBody AdminReportStatusUpdateRequest request) {
+        return adminReportService.updateReportStatus(reportId, request.getStatus());
     }
 }

--- a/src/main/java/com/roommate/admin/dto/AdminReportStatusUpdateRequest.java
+++ b/src/main/java/com/roommate/admin/dto/AdminReportStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminReportStatusUpdateRequest {
+    private String status;
+}

--- a/src/main/java/com/roommate/admin/service/AdminReportService.java
+++ b/src/main/java/com/roommate/admin/service/AdminReportService.java
@@ -1,7 +1,10 @@
 package com.roommate.admin.service;
 
+import com.roommate.admin.dto.AdminReportListItemResponse;
 import com.roommate.admin.dto.AdminReportListResponse;
 
 public interface AdminReportService {
     AdminReportListResponse getReports(int page, int size);
+
+    AdminReportListItemResponse updateReportStatus(Long reportId, String status);
 }

--- a/src/main/java/com/roommate/admin/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminReportServiceImpl.java
@@ -2,6 +2,8 @@ package com.roommate.admin.service;
 
 import com.roommate.admin.dto.AdminReportListItemResponse;
 import com.roommate.admin.dto.AdminReportListResponse;
+import com.roommate.common.exception.ApiException;
+import com.roommate.common.exception.ErrorCode;
 import com.roommate.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,5 +28,27 @@ public class AdminReportServiceImpl implements AdminReportService {
         boolean hasNext = safePage < totalPages;
 
         return new AdminReportListResponse(items, safePage, safeSize, totalCount, totalPages, hasNext);
+    }
+
+    @Override
+    public AdminReportListItemResponse updateReportStatus(Long reportId, String status) {
+        if (!"RESOLVED".equals(status)) {
+            throw new ApiException(ErrorCode.ADMIN_REPORT_STATUS_INVALID);
+        }
+
+        AdminReportListItemResponse report = reportRepository.findReportForAdminById(reportId)
+                .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_REPORT_NOT_FOUND));
+
+        if ("RESOLVED".equals(report.getStatus())) {
+            throw new ApiException(ErrorCode.ADMIN_REPORT_ALREADY_RESOLVED);
+        }
+
+        int updatedCount = reportRepository.updateReportStatusForAdmin(reportId, status);
+        if (updatedCount != 1) {
+            throw new ApiException(ErrorCode.ADMIN_REPORT_RESOLVE_FAILED);
+        }
+
+        return reportRepository.findReportForAdminById(reportId)
+                .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_REPORT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/roommate/common/exception/ErrorCode.java
+++ b/src/main/java/com/roommate/common/exception/ErrorCode.java
@@ -33,6 +33,10 @@ public enum ErrorCode {
     ADMIN_SELF_STATUS_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "AD005", "관리자는 본인 계정을 정지하거나 해제할 수 없습니다."),
     ADMIN_TARGET_ADMIN_NOT_ALLOWED(HttpStatus.FORBIDDEN, "AD006", "다른 관리자 계정은 정지하거나 해제할 수 없습니다."),
     ADMIN_MEMBER_STATUS_INVALID(HttpStatus.BAD_REQUEST, "AD007", "변경할 수 없는 회원 상태입니다."),
+    ADMIN_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "AD008", "관리 대상 신고가 존재하지 않습니다."),
+    ADMIN_REPORT_ALREADY_RESOLVED(HttpStatus.CONFLICT, "AD009", "이미 처리 완료된 신고입니다."),
+    ADMIN_REPORT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "AD010", "변경할 수 없는 신고 상태입니다."),
+    ADMIN_REPORT_RESOLVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AD011", "신고 처리에 실패했습니다."),
 
     // ===== MEMBER / 회원 관련 =====
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M001", "이미 사용중인 이메일입니다."),

--- a/src/main/java/com/roommate/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/roommate/domain/report/repository/ReportRepository.java
@@ -5,10 +5,15 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface ReportRepository {
     long countReportsForAdmin();
 
     List<AdminReportListItemResponse> findReportsForAdmin(@Param("limit") int limit, @Param("offset") int offset);
+
+    Optional<AdminReportListItemResponse> findReportForAdminById(@Param("reportId") Long reportId);
+
+    int updateReportStatusForAdmin(@Param("reportId") Long reportId, @Param("status") String status);
 }

--- a/src/main/resources/mapper/report/Report.xml
+++ b/src/main/resources/mapper/report/Report.xml
@@ -28,4 +28,29 @@
         LIMIT #{limit}
         OFFSET #{offset}
     </select>
+
+    <select id="findReportForAdminById" resultType="com.roommate.admin.dto.AdminReportListItemResponse">
+        SELECT
+            r.report_id AS reportId,
+            r.target_member_id AS targetMemberId,
+            target.email AS targetMemberEmail,
+            target.name AS targetMemberName,
+            r.reporter_id AS reporterId,
+            reporter.email AS reporterEmail,
+            reporter.name AS reporterName,
+            r.reason AS reason,
+            r.status AS status,
+            r.report_created_at AS reportCreatedAt
+        FROM report r
+        INNER JOIN members target ON target.member_id = r.target_member_id
+        INNER JOIN members reporter ON reporter.member_id = r.reporter_id
+        WHERE r.report_id = #{reportId}
+    </select>
+
+    <update id="updateReportStatusForAdmin">
+        UPDATE report
+        SET status = #{status}
+        WHERE report_id = #{reportId}
+        AND status = 'PENDING'
+    </update>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -71,11 +71,12 @@
               <th scope="col">사유</th>
               <th scope="col">상태</th>
               <th scope="col">생성일</th>
+              <th scope="col">관리</th>
             </tr>
           </thead>
           <tbody id="adminReportTableBody">
             <tr class="data-table-empty">
-              <td colspan="6">신고 목록을 불러오는 중입니다.</td>
+              <td colspan="7">신고 목록을 불러오는 중입니다.</td>
             </tr>
           </tbody>
         </table>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -210,6 +210,31 @@ body {
   color: #027a48;
 }
 
+.report-action-btn {
+  min-width: 76px;
+  height: 34px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #101828;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.report-action-btn:hover {
+  background: #f9fafb;
+}
+
+.report-action-btn:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.report-action-empty {
+  color: #98a2b3;
+}
+
 @media (max-width: 720px) {
   .admin-page {
     padding: 32px 18px 72px;

--- a/src/main/webapp/resources/js/admin/reportList.js
+++ b/src/main/webapp/resources/js/admin/reportList.js
@@ -32,7 +32,7 @@ async function loadReports() {
     count.textContent = "신고 목록을 불러오지 못했습니다.";
     tableBody.innerHTML = `
       <tr class="data-table-empty">
-        <td colspan="6">신고 목록을 불러오지 못했습니다.</td>
+        <td colspan="7">신고 목록을 불러오지 못했습니다.</td>
       </tr>
     `;
   }
@@ -61,13 +61,14 @@ function renderReports() {
   if (visibleReports.length === 0) {
     tableBody.innerHTML = `
       <tr class="data-table-empty">
-        <td colspan="6">${emptyMessage()}</td>
+        <td colspan="7">${emptyMessage()}</td>
       </tr>
     `;
     return;
   }
 
   tableBody.innerHTML = visibleReports.map(renderReportRow).join("");
+  bindActionButtons(tableBody);
 }
 
 function renderReportRow(report) {
@@ -79,6 +80,7 @@ function renderReportRow(report) {
       <td class="report-reason">${escapeHtml(report.reason)}</td>
       <td><span class="report-status ${statusClass(report.status)}">${escapeHtml(statusLabel(report.status))}</span></td>
       <td>${escapeHtml(formatDate(report.report_created_at))}</td>
+      <td>${renderActionCell(report)}</td>
     </tr>
   `;
 }
@@ -90,6 +92,60 @@ function renderParty(name, email) {
       <span>${escapeHtml(email)}</span>
     </div>
   `;
+}
+
+function renderActionCell(report) {
+  if (report.status === "RESOLVED") {
+    return '<span class="report-action-empty">-</span>';
+  }
+
+  return `
+    <button
+      type="button"
+      class="report-action-btn"
+      data-report-id="${escapeHtml(report.report_id)}">
+      처리 완료
+    </button>
+  `;
+}
+
+function bindActionButtons(container) {
+  container.querySelectorAll(".report-action-btn").forEach((button) => {
+    button.addEventListener("click", async () => {
+      await resolveReport(button);
+    });
+  });
+}
+
+async function resolveReport(button) {
+  const reportId = button.dataset.reportId;
+  if (!reportId) return;
+
+  const ok = confirm("이 신고를 처리 완료로 변경하시겠습니까?");
+  if (!ok) return;
+
+  button.disabled = true;
+
+  try {
+    const response = await apiRequest(`${contextPath}/api/admin/reports/${encodeURIComponent(reportId)}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status: "RESOLVED" }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`admin report status api failed: ${response.status}`);
+    }
+
+    const updatedReport = await response.json();
+    reports = reports.map((report) => (
+      report.report_id === updatedReport.report_id ? updatedReport : report
+    ));
+    renderReports();
+  } catch (error) {
+    console.error(error);
+    alert("신고 상태를 변경하지 못했습니다.");
+    button.disabled = false;
+  }
 }
 
 function emptyMessage() {


### PR DESCRIPTION
  ## 개요                                                                                                             
  관리자가 대기 중인 신고를 처리 완료 상태로 변경할 수 있는 기능을 추가했습니다.                                      
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 신고 처리 완료 API 추가                                                                                           
    - `PATCH /api/admin/reports/{reportId}/status`                                                                    
  - 신고 상태 변경 요청 DTO 추가                                                                                      
  - 신고 처리 완료 서비스 로직 추가                                                                                   
  - 신고 목록 화면에 `처리 완료` 액션 추가                                                                            
  - 신고 처리 관련 예외 코드 추가                                                                                     
                                                                                                                      
  ## 정책                                                                                                             
  - 허용되는 상태 변경은 `PENDING -> RESOLVED`만 지원                                                                 
  - 이미 `RESOLVED` 상태인 신고는 다시 처리할 수 없음                                                                 
  - 현재 이슈 범위에서는 처리 완료 여부만 관리                                                                        
  - 처리 사유, 신고자 안내 문구, 처리자/처리 시각 기록은 후속 이슈에서 확장 가능                                      
                                                                                                                      
  ## 구현 내용                                                                                                        
  - 대기 중인 신고에만 `처리 완료` 버튼 표시                                                                          
  - 처리 완료 후 목록 상태를 즉시 갱신                                                                                
  - 처리 완료된 신고는 액션 버튼 대신 `-` 표시                                                                        
  - 재처리 요청은 서버에서 차단                                                                                       
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - 대기 신고 처리 요청 후 `RESOLVED` 변경 확인                                                                       
  - 동일 신고 재처리 요청 시 `409` 반환 확인                                                                          
                                                                                                                      
  ## 관련 이슈
  - closes #54