### PR TITLE
feat: 관리자 신고 처리 상세 입력 UI 추가 

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -84,6 +84,43 @@
     </section>
   </main>
 
+  <div class="report-resolution-modal" id="reportResolutionModal" aria-hidden="true">
+    <div class="report-resolution-backdrop" data-close-resolution-modal></div>
+    <section class="report-resolution-dialog" role="dialog" aria-modal="true" aria-labelledby="reportResolutionTitle">
+      <div class="report-resolution-header">
+        <h2 id="reportResolutionTitle">신고 처리</h2>
+        <button type="button" class="report-resolution-close" data-close-resolution-modal aria-label="닫기">x</button>
+      </div>
+
+      <form id="reportResolutionForm" class="report-resolution-form">
+        <label>
+          <span>처리 결과</span>
+          <select name="resolution_type" required>
+            <option value="">선택</option>
+            <option value="ACCEPTED">신고 인정</option>
+            <option value="REJECTED">신고 반려</option>
+            <option value="NO_ACTION">조치 없음</option>
+          </select>
+        </label>
+
+        <label>
+          <span>신고자 안내 문구</span>
+          <textarea
+            name="resolution_message"
+            rows="5"
+            maxlength="500"
+            placeholder="처리 결과와 안내 내용을 입력하세요."
+            required></textarea>
+        </label>
+
+        <div class="report-resolution-actions">
+          <button type="button" class="btn-secondary" data-close-resolution-modal>취소</button>
+          <button type="submit" class="btn-primary">처리 완료</button>
+        </div>
+      </form>
+    </section>
+  </div>
+
   <script>
     window.contextPath = "${pageContext.request.contextPath}";
   </script>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -235,6 +235,123 @@ body {
   color: #98a2b3;
 }
 
+.report-resolution-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: none;
+}
+
+.report-resolution-modal.is-open {
+  display: block;
+}
+
+.report-resolution-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(16, 24, 40, 0.45);
+}
+
+.report-resolution-dialog {
+  position: relative;
+  width: min(520px, calc(100vw - 32px));
+  margin: 10vh auto 0;
+  padding: 24px;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 24px 64px rgba(16, 24, 40, 0.24);
+}
+
+.report-resolution-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.report-resolution-header h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.report-resolution-close {
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: #f2f4f7;
+  color: #344054;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.report-resolution-form {
+  display: grid;
+  gap: 18px;
+  margin-top: 22px;
+}
+
+.report-resolution-form label {
+  display: grid;
+  gap: 8px;
+}
+
+.report-resolution-form span {
+  color: #344054;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.report-resolution-form select,
+.report-resolution-form textarea {
+  width: 100%;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #101828;
+  font: inherit;
+}
+
+.report-resolution-form select {
+  height: 42px;
+  padding: 0 12px;
+}
+
+.report-resolution-form textarea {
+  resize: vertical;
+  min-height: 120px;
+  padding: 12px;
+  line-height: 1.5;
+}
+
+.report-resolution-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.btn-secondary,
+.btn-primary {
+  min-width: 84px;
+  height: 40px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.btn-secondary {
+  border: 1px solid #d0d5dd;
+  background: #fff;
+  color: #344054;
+}
+
+.btn-primary {
+  border: 1px solid #101828;
+  background: #101828;
+  color: #fff;
+}
+
 @media (max-width: 720px) {
   .admin-page {
     padding: 32px 18px 72px;

--- a/src/main/webapp/resources/js/admin/reportList.js
+++ b/src/main/webapp/resources/js/admin/reportList.js
@@ -3,9 +3,11 @@ import { apiRequest } from "../common/apiClient.js";
 const contextPath = window.contextPath || "";
 let reports = [];
 let activeStatus = "ALL";
+let selectedReportId = null;
 
 document.addEventListener("DOMContentLoaded", async () => {
   bindFilterButtons();
+  bindResolutionModal();
   await loadReports();
 });
 
@@ -47,6 +49,21 @@ function bindFilterButtons() {
       });
       renderReports();
     });
+  });
+}
+
+function bindResolutionModal() {
+  const modal = document.getElementById("reportResolutionModal");
+  const form = document.getElementById("reportResolutionForm");
+  if (!modal || !form) return;
+
+  modal.querySelectorAll("[data-close-resolution-modal]").forEach((button) => {
+    button.addEventListener("click", closeResolutionModal);
+  });
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    await submitResolution(form);
   });
 }
 
@@ -104,32 +121,61 @@ function renderActionCell(report) {
       type="button"
       class="report-action-btn"
       data-report-id="${escapeHtml(report.report_id)}">
-      처리 완료
+      처리
     </button>
   `;
 }
 
 function bindActionButtons(container) {
   container.querySelectorAll(".report-action-btn").forEach((button) => {
-    button.addEventListener("click", async () => {
-      await resolveReport(button);
+    button.addEventListener("click", () => {
+      openResolutionModal(button.dataset.reportId);
     });
   });
 }
 
-async function resolveReport(button) {
-  const reportId = button.dataset.reportId;
-  if (!reportId) return;
+function openResolutionModal(reportId) {
+  const modal = document.getElementById("reportResolutionModal");
+  const form = document.getElementById("reportResolutionForm");
+  if (!modal || !form || !reportId) return;
 
-  const ok = confirm("이 신고를 처리 완료로 변경하시겠습니까?");
-  if (!ok) return;
+  selectedReportId = reportId;
+  form.reset();
+  modal.classList.add("is-open");
+  modal.setAttribute("aria-hidden", "false");
+}
 
-  button.disabled = true;
+function closeResolutionModal() {
+  const modal = document.getElementById("reportResolutionModal");
+  const form = document.getElementById("reportResolutionForm");
+  if (!modal || !form) return;
+
+  selectedReportId = null;
+  form.reset();
+  modal.classList.remove("is-open");
+  modal.setAttribute("aria-hidden", "true");
+}
+
+async function submitResolution(form) {
+  if (!selectedReportId) return;
+
+  const submitButton = form.querySelector('button[type="submit"]');
+  const formData = new FormData(form);
+  const resolutionType = String(formData.get("resolution_type") || "");
+  const resolutionMessage = String(formData.get("resolution_message") || "").trim();
+
+  if (!resolutionType || !resolutionMessage) return;
+
+  submitButton.disabled = true;
 
   try {
-    const response = await apiRequest(`${contextPath}/api/admin/reports/${encodeURIComponent(reportId)}/status`, {
+    const response = await apiRequest(`${contextPath}/api/admin/reports/${encodeURIComponent(selectedReportId)}/status`, {
       method: "PATCH",
-      body: JSON.stringify({ status: "RESOLVED" }),
+      body: JSON.stringify({
+        status: "RESOLVED",
+        resolution_type: resolutionType,
+        resolution_message: resolutionMessage,
+      }),
     });
 
     if (!response.ok) {
@@ -140,11 +186,13 @@ async function resolveReport(button) {
     reports = reports.map((report) => (
       report.report_id === updatedReport.report_id ? updatedReport : report
     ));
+    closeResolutionModal();
     renderReports();
   } catch (error) {
     console.error(error);
     alert("신고 상태를 변경하지 못했습니다.");
-    button.disabled = false;
+  } finally {
+    submitButton.disabled = false;
   }
 }
 


### PR DESCRIPTION
 ## 개요                                                                                                             
  관리자가 신고를 처리할 때 처리 결과와 신고자 안내 문구를 함께 입력할 수 있도록 상세 입력 UI를 추가했습니다.         
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 신고 처리 모달 추가                                                                                               
  - 처리 결과 선택 UI 추가                                                                                            
    - 신고 인정                                                                                                       
    - 신고 반려                                                                                                       
    - 조치 없음                                                                                                       
  - 신고자 안내 문구 입력 필드 추가                                                                                   
  - 기존 `처리 완료` 버튼을 상세 입력 모달을 여는 `처리` 버튼으로 변경                                                
  - 처리 완료 후 신고 목록 즉시 갱신                                                                                  
                                                                                                                      
  ## 구현 내용                                                                                                        
  - 대기 중인 신고의 `처리` 버튼 클릭 시 입력 모달 표시                                                               
  - 처리 결과와 안내 문구를 입력해야 제출 가능                                                                        
  - 제출 시 기존 신고 처리 API에 아래 값을 함께 전송                                                                  
    - `status`                                                                                                        
    - `resolution_type`                                                                                               
    - `resolution_message`                                                                                            
  - 처리 성공 후 목록 상태를 즉시 반영                                                                                
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - `/admin` 페이지 응답 `200` 확인                                                                                   
  - 관리자 페이지에 신고 처리 모달 포함 확인                                                                          
  - `reportList.js`에서 상세 처리 필드 전송 로직 포함 확인                                                            
  - 브라우저에서 대기 신고의 `처리` 버튼 클릭 시 입력 모달 표시 확인                                                  
                                                                                                                      
  ## 관련 이슈                                                                                                        
  - closes #58