### PR TITLE
feat: 신고자 처리 결과 조회 기능 추가

### DIFF
--- a/src/main/java/com/roommate/domain/report/controller/ReportRestController.java
+++ b/src/main/java/com/roommate/domain/report/controller/ReportRestController.java
@@ -1,4 +1,25 @@
 package com.roommate.domain.report.controller;
 
+import com.roommate.common.security.UserDetailsImpl;
+import com.roommate.domain.report.dto.MyReportListItemResponse;
+import com.roommate.domain.report.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
 public class ReportRestController {
+
+    private final ReportService reportService;
+
+    @GetMapping("/me")
+    public List<MyReportListItemResponse> getMyReports(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return reportService.getMyReports(userDetails.getMemberId());
+    }
 }

--- a/src/main/java/com/roommate/domain/report/dto/MyReportListItemResponse.java
+++ b/src/main/java/com/roommate/domain/report/dto/MyReportListItemResponse.java
@@ -1,0 +1,24 @@
+package com.roommate.domain.report.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Getter
+@AllArgsConstructor
+public class MyReportListItemResponse {
+    private Long reportId;
+    private Long targetMemberId;
+    private String targetMemberEmail;
+    private String targetMemberName;
+    private String reason;
+    private String status;
+    private String resolutionType;
+    private String resolutionMessage;
+    private LocalDateTime processedAt;
+    private LocalDateTime reportCreatedAt;
+}

--- a/src/main/java/com/roommate/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/roommate/domain/report/repository/ReportRepository.java
@@ -1,6 +1,7 @@
 package com.roommate.domain.report.repository;
 
 import com.roommate.admin.dto.AdminReportListItemResponse;
+import com.roommate.domain.report.dto.MyReportListItemResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -20,4 +21,6 @@ public interface ReportRepository {
                                    @Param("resolutionType") String resolutionType,
                                    @Param("resolutionMessage") String resolutionMessage,
                                    @Param("processedBy") Long processedBy);
+
+    List<MyReportListItemResponse> findMyReports(@Param("reporterId") Long reporterId);
 }

--- a/src/main/java/com/roommate/domain/report/service/ReportSerivceImp.java
+++ b/src/main/java/com/roommate/domain/report/service/ReportSerivceImp.java
@@ -1,4 +1,20 @@
 package com.roommate.domain.report.service;
 
-public class ReportSerivceImp implements ReportService{
+import com.roommate.domain.report.dto.MyReportListItemResponse;
+import com.roommate.domain.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportSerivceImp implements ReportService {
+
+    private final ReportRepository reportRepository;
+
+    @Override
+    public List<MyReportListItemResponse> getMyReports(Long reporterId) {
+        return reportRepository.findMyReports(reporterId);
+    }
 }

--- a/src/main/java/com/roommate/domain/report/service/ReportService.java
+++ b/src/main/java/com/roommate/domain/report/service/ReportService.java
@@ -1,4 +1,9 @@
 package com.roommate.domain.report.service;
 
+import com.roommate.domain.report.dto.MyReportListItemResponse;
+
+import java.util.List;
+
 public interface ReportService {
+    List<MyReportListItemResponse> getMyReports(Long reporterId);
 }

--- a/src/main/resources/mapper/report/Report.xml
+++ b/src/main/resources/mapper/report/Report.xml
@@ -71,4 +71,22 @@
         WHERE report_id = #{reportId}
         AND status = 'PENDING'
     </update>
+
+    <select id="findMyReports" resultType="com.roommate.domain.report.dto.MyReportListItemResponse">
+        SELECT
+            r.report_id AS reportId,
+            r.target_member_id AS targetMemberId,
+            target.email AS targetMemberEmail,
+            target.name AS targetMemberName,
+            r.reason AS reason,
+            r.status AS status,
+            r.resolution_type AS resolutionType,
+            r.resolution_message AS resolutionMessage,
+            r.processed_at AS processedAt,
+            r.report_created_at AS reportCreatedAt
+        FROM report r
+        INNER JOIN members target ON target.member_id = r.target_member_id
+        WHERE r.reporter_id = #{reporterId}
+        ORDER BY r.report_created_at DESC, r.report_id DESC
+    </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/members/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/members/mypage.jsp
@@ -120,7 +120,14 @@
   </section>
 
   <section class="mypage-tab-content" id="tab-activities" style="display:none;">
-    <!-- TODO: 활동 내역 내용 -->
+    <div class="mypage-section-header">
+      <h2 class="mypage-section-title">신고 내역</h2>
+      <p class="mypage-section-subtitle">내가 접수한 신고와 처리 결과를 확인할 수 있습니다.</p>
+    </div>
+
+    <div id="myReportList" class="my-report-list">
+      <p class="favorite-empty">신고 내역을 불러오는 중입니다.</p>
+    </div>
   </section>
 
   <!-- 🔐 계정 설정 탭 안에 비밀번호 변경 카드 + 모달 배치하면 됨 -->

--- a/src/main/webapp/resources/css/member/mypage-view.css
+++ b/src/main/webapp/resources/css/member/mypage-view.css
@@ -575,10 +575,87 @@
   color:#9ca3af;
 }
 
+.my-report-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.my-report-card {
+  padding: 18px;
+  border: 1px solid #eee;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.05);
+}
+
+.my-report-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.my-report-head h4,
+.my-report-head p {
+  margin: 0;
+}
+
+.my-report-head p {
+  margin-top: 4px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.my-report-status {
+  align-self: flex-start;
+  padding: 7px 12px;
+  border-radius: 999px;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 900;
+}
+
+.my-report-status.PENDING {
+  background: #b54708;
+}
+
+.my-report-status.RESOLVED {
+  background: #027a48;
+}
+
+.my-report-meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0 0;
+}
+
+.my-report-meta dt {
+  color: #667085;
+  font-size: 13px;
+}
+
+.my-report-meta dd {
+  margin: 6px 0 0;
+  color: #111827;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.my-report-message {
+  margin-top: 18px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #f9fafb;
+  color: #475467;
+  line-height: 1.6;
+}
+
 /* (선택) 모바일 대응 */
 @media (max-width: 720px){
   .my-post-card{ flex-direction:column; }
   .my-post-thumb{ width:100%; height:180px; flex:auto; }
   .my-post-actions{ position:static; justify-content:flex-end; margin-top:10px; }
   .my-post-status{ top:14px; right:14px; }
+  .my-report-meta{ grid-template-columns: 1fr 1fr; }
 }

--- a/src/main/webapp/resources/js/member/mypageView.js
+++ b/src/main/webapp/resources/js/member/mypageView.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       loadMyProfile(),
       loadMyFavorites(),
       loadMyRooms(),
+      loadMyReports(),
     ]);
   } catch (e) {
     console.error("mypage view init error:", e);
@@ -275,6 +276,64 @@ async function loadMyRooms() {
   }
 }
 
+async function loadMyReports() {
+  const wrap = document.getElementById("myReportList");
+  if (!wrap) return;
+
+  wrap.innerHTML = '<p class="favorite-empty">신고 내역을 불러오는 중입니다.</p>';
+
+  try {
+    const res = await apiRequest("/api/reports/me", { method: "GET" });
+    if (!res.ok) throw new Error("my reports load failed: " + res.status);
+
+    const reports = await res.json();
+    if (!Array.isArray(reports) || reports.length === 0) {
+      wrap.innerHTML = '<p class="favorite-empty">접수한 신고가 없습니다.</p>';
+      return;
+    }
+
+    wrap.innerHTML = reports.map(renderMyReportCard).join("");
+  } catch (e) {
+    console.error("[mypage] loadMyReports error:", e);
+    wrap.innerHTML = '<p class="favorite-empty">신고 내역을 불러오지 못했습니다.</p>';
+  }
+}
+
+function renderMyReportCard(report) {
+  return `
+    <article class="my-report-card">
+      <div class="my-report-head">
+        <div>
+          <h4>${escapeHtml(report.target_member_name || "대상 회원")}</h4>
+          <p>${escapeHtml(report.target_member_email || "-")}</p>
+        </div>
+        <span class="my-report-status ${reportStatusClass(report.status)}">${escapeHtml(reportStatusText(report.status))}</span>
+      </div>
+      <dl class="my-report-meta">
+        <div>
+          <dt>신고 사유</dt>
+          <dd>${escapeHtml(report.reason || "-")}</dd>
+        </div>
+        <div>
+          <dt>접수일</dt>
+          <dd>${escapeHtml(formatDate(report.report_created_at))}</dd>
+        </div>
+        <div>
+          <dt>처리 결과</dt>
+          <dd>${escapeHtml(resolutionTypeText(report.resolution_type))}</dd>
+        </div>
+        <div>
+          <dt>처리일</dt>
+          <dd>${escapeHtml(report.processed_at ? formatDate(report.processed_at) : "-")}</dd>
+        </div>
+      </dl>
+      <div class="my-report-message">
+        ${escapeHtml(report.resolution_message || "아직 처리 결과가 등록되지 않았습니다.")}
+      </div>
+    </article>
+  `;
+}
+
 function renderMyRoomCard(room) {
   const roomId = room.roomId ?? room.room_id;
   const title = room.roomTitle ?? room.room_title ?? room.title ?? "제목 없음";
@@ -468,6 +527,23 @@ function statusText(status) {
     case "HIDDEN": return "비공개";
     default: return "상태 미확인";
   }
+}
+
+function reportStatusClass(status) {
+  if (status === "RESOLVED") return "RESOLVED";
+  return "PENDING";
+}
+
+function reportStatusText(status) {
+  if (status === "RESOLVED") return "처리완료";
+  return "대기";
+}
+
+function resolutionTypeText(value) {
+  if (value === "ACCEPTED") return "신고 인정";
+  if (value === "REJECTED") return "신고 반려";
+  if (value === "NO_ACTION") return "조치 없음";
+  return "-";
 }
 
 function formatMoney(value) {


### PR DESCRIPTION
  ## 개요                                                                                                             
  신고자가 본인이 접수한 신고의 처리 상태와 처리 결과를 확인할 수 있도록 조회 API와 마이페이지 화면을 추가했습니다.   
                                                                                                                      
  ## 변경 사항                                                                                                        
  - 본인 신고 목록 조회 API 추가                                                                                      
    - `GET /api/reports/me`                                                                                           
  - 신고자용 응답 DTO 추가                                                                                            
  - 신고 도메인 서비스/저장소 로직 추가                                                                               
  - 마이페이지 활동 탭에 신고 내역 영역 추가                                                                          
  - 신고 처리 상태, 처리 결과, 처리 안내 문구 표시 UI 추가                                                            
                                                                                                                      
  ## 표시 정보                                                                                                        
  - 신고 대상                                                                                                         
  - 신고 사유
  - 접수일                                                                                                            
  - 처리 상태                                                                                                         
  - 처리 결과                                                                                                         
  - 처리일                                                                                                            
  - 관리자 안내 문구                                                                                                  
                                                                                                                      
  ## 구현 내용                                                                                                        
  - 로그인한 사용자 본인의 신고만 조회                                                                                
  - 처리 전 신고는 대기 상태와 기본 안내 문구 표시                                                                    
  - 처리 완료 신고는 처리 결과와 관리자 안내 문구 표시                                                                
  - 마이페이지 기존 활동 탭을 신고 내역 확인 영역으로 활용                                                            
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - 로그인 사용자 기준 `GET /api/reports/me` 응답 확인                                                                
  - 테스트 계정에서 신고 목록 조회 확인                                                                               
  - `/members/mypage` 응답 `200` 확인                                                                                 
  - 마이페이지 HTML에 신고 내역 영역 포함 확인                                                                        
                                                                                                                      
  ## 관련 이슈                                                                                                        
  - closes #60 