### PR TITLE
feat: 관리자 작업 로그 추가 

### DIFF
--- a/src/main/java/com/roommate/admin/controller/AdminRestController.java
+++ b/src/main/java/com/roommate/admin/controller/AdminRestController.java
@@ -1,11 +1,13 @@
 package com.roommate.admin.controller;
 
+import com.roommate.admin.dto.AdminActionLogListResponse;
 import com.roommate.admin.dto.AdminMemberListItemResponse;
 import com.roommate.admin.dto.AdminMemberListResponse;
 import com.roommate.admin.dto.AdminMemberStatusUpdateRequest;
 import com.roommate.admin.dto.AdminReportListResponse;
 import com.roommate.admin.dto.AdminReportListItemResponse;
 import com.roommate.admin.dto.AdminReportStatusUpdateRequest;
+import com.roommate.admin.service.AdminActionLogService;
 import com.roommate.admin.service.AdminMemberService;
 import com.roommate.admin.service.AdminReportService;
 import com.roommate.common.security.UserDetailsImpl;
@@ -26,11 +28,18 @@ public class AdminRestController {
 
     private final AdminMemberService adminMemberService;
     private final AdminReportService adminReportService;
+    private final AdminActionLogService adminActionLogService;
 
     @GetMapping("/members")
     public AdminMemberListResponse getMembers(@RequestParam(defaultValue = "1") int page,
                                               @RequestParam(defaultValue = "20") int size) {
         return adminMemberService.getMembers(page, size);
+    }
+
+    @GetMapping("/action-logs")
+    public AdminActionLogListResponse getActionLogs(@RequestParam(defaultValue = "1") int page,
+                                                    @RequestParam(defaultValue = "20") int size) {
+        return adminActionLogService.getLogs(page, size);
     }
 
     @PatchMapping("/members/{memberId}/status")

--- a/src/main/java/com/roommate/admin/dto/AdminActionLogItemResponse.java
+++ b/src/main/java/com/roommate/admin/dto/AdminActionLogItemResponse.java
@@ -1,0 +1,39 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AdminActionLogItemResponse {
+
+    @JsonProperty("admin_action_log_id")
+    private final Long adminActionLogId;
+
+    @JsonProperty("admin_id")
+    private final Long adminId;
+
+    @JsonProperty("admin_email")
+    private final String adminEmail;
+
+    @JsonProperty("admin_name")
+    private final String adminName;
+
+    @JsonProperty("action_type")
+    private final String actionType;
+
+    @JsonProperty("target_type")
+    private final String targetType;
+
+    @JsonProperty("target_id")
+    private final Long targetId;
+
+    @JsonProperty("action_detail")
+    private final String actionDetail;
+
+    @JsonProperty("created_at")
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/roommate/admin/dto/AdminActionLogListResponse.java
+++ b/src/main/java/com/roommate/admin/dto/AdminActionLogListResponse.java
@@ -1,0 +1,27 @@
+package com.roommate.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AdminActionLogListResponse {
+
+    private final List<AdminActionLogItemResponse> items;
+
+    private final int page;
+
+    private final int size;
+
+    @JsonProperty("total_count")
+    private final long totalCount;
+
+    @JsonProperty("total_pages")
+    private final int totalPages;
+
+    @JsonProperty("has_next")
+    private final boolean hasNext;
+}

--- a/src/main/java/com/roommate/admin/service/AdminActionLogService.java
+++ b/src/main/java/com/roommate/admin/service/AdminActionLogService.java
@@ -1,0 +1,11 @@
+package com.roommate.admin.service;
+
+import com.roommate.admin.dto.AdminActionLogListResponse;
+
+public interface AdminActionLogService {
+    void logMemberStatusChange(Long adminId, Long memberId, String actionType);
+
+    void logReportResolved(Long adminId, Long reportId, String resolutionType);
+
+    AdminActionLogListResponse getLogs(int page, int size);
+}

--- a/src/main/java/com/roommate/admin/service/AdminActionLogServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminActionLogServiceImpl.java
@@ -1,0 +1,40 @@
+package com.roommate.admin.service;
+
+import com.roommate.admin.dto.AdminActionLogItemResponse;
+import com.roommate.admin.dto.AdminActionLogListResponse;
+import com.roommate.domain.admin.repository.AdminActionLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminActionLogServiceImpl implements AdminActionLogService {
+
+    private final AdminActionLogRepository adminActionLogRepository;
+
+    @Override
+    public void logMemberStatusChange(Long adminId, Long memberId, String actionType) {
+        adminActionLogRepository.save(adminId, actionType, "MEMBER", memberId, null);
+    }
+
+    @Override
+    public void logReportResolved(Long adminId, Long reportId, String resolutionType) {
+        adminActionLogRepository.save(adminId, "REPORT_RESOLVED", "REPORT", reportId, resolutionType);
+    }
+
+    @Override
+    public AdminActionLogListResponse getLogs(int page, int size) {
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.max(size, 1);
+        int offset = (safePage - 1) * safeSize;
+
+        long totalCount = adminActionLogRepository.countLogsForAdmin();
+        List<AdminActionLogItemResponse> items = adminActionLogRepository.findLogsForAdmin(safeSize, offset);
+        int totalPages = totalCount == 0 ? 0 : (int) Math.ceil((double) totalCount / safeSize);
+        boolean hasNext = safePage < totalPages;
+
+        return new AdminActionLogListResponse(items, safePage, safeSize, totalCount, totalPages, hasNext);
+    }
+}

--- a/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminMemberServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 public class AdminMemberServiceImpl implements AdminMemberService {
 
     private final MemberRepository memberRepository;
+    private final AdminActionLogService adminActionLogService;
 
     @Override
     public AdminMemberListResponse getMembers(int page, int size) {
@@ -56,6 +57,12 @@ public class AdminMemberServiceImpl implements AdminMemberService {
         if (updatedCount != 1) {
             throw new ApiException(ErrorCode.ADMIN_MEMBER_BAN_FAILED);
         }
+
+        adminActionLogService.logMemberStatusChange(
+                currentAdminId,
+                memberId,
+                status == MemberStatusEnum.BANNED ? "MEMBER_BANNED" : "MEMBER_UNBANNED"
+        );
 
         member.setStatus(status);
         return new AdminMemberListItemResponse(

--- a/src/main/java/com/roommate/admin/service/AdminReportServiceImpl.java
+++ b/src/main/java/com/roommate/admin/service/AdminReportServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class AdminReportServiceImpl implements AdminReportService {
 
     private final ReportRepository reportRepository;
+    private final AdminActionLogService adminActionLogService;
 
     @Override
     public AdminReportListResponse getReports(int page, int size) {
@@ -63,6 +64,8 @@ public class AdminReportServiceImpl implements AdminReportService {
         if (updatedCount != 1) {
             throw new ApiException(ErrorCode.ADMIN_REPORT_RESOLVE_FAILED);
         }
+
+        adminActionLogService.logReportResolved(processedBy, reportId, resolutionType);
 
         return reportRepository.findReportForAdminById(reportId)
                 .orElseThrow(() -> new ApiException(ErrorCode.ADMIN_REPORT_NOT_FOUND));

--- a/src/main/java/com/roommate/domain/admin/repository/AdminActionLogRepository.java
+++ b/src/main/java/com/roommate/domain/admin/repository/AdminActionLogRepository.java
@@ -1,0 +1,20 @@
+package com.roommate.domain.admin.repository;
+
+import com.roommate.admin.dto.AdminActionLogItemResponse;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AdminActionLogRepository {
+    void save(@Param("adminId") Long adminId,
+              @Param("actionType") String actionType,
+              @Param("targetType") String targetType,
+              @Param("targetId") Long targetId,
+              @Param("actionDetail") String actionDetail);
+
+    long countLogsForAdmin();
+
+    List<AdminActionLogItemResponse> findLogsForAdmin(@Param("limit") int limit, @Param("offset") int offset);
+}

--- a/src/main/resources/mapper/admin/AdminActionLog.xml
+++ b/src/main/resources/mapper/admin/AdminActionLog.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.roommate.domain.admin.repository.AdminActionLogRepository">
+    <insert id="save">
+        INSERT INTO admin_action_log (
+            admin_id,
+            action_type,
+            target_type,
+            target_id,
+            action_detail
+        )
+        VALUES (
+            #{adminId},
+            #{actionType},
+            #{targetType},
+            #{targetId},
+            #{actionDetail}
+        )
+    </insert>
+
+    <select id="countLogsForAdmin" resultType="long">
+        SELECT COUNT(*)
+        FROM admin_action_log
+    </select>
+
+    <select id="findLogsForAdmin" resultType="com.roommate.admin.dto.AdminActionLogItemResponse">
+        SELECT
+            l.admin_action_log_id AS adminActionLogId,
+            l.admin_id AS adminId,
+            m.email AS adminEmail,
+            m.name AS adminName,
+            l.action_type AS actionType,
+            l.target_type AS targetType,
+            l.target_id AS targetId,
+            l.action_detail AS actionDetail,
+            l.created_at AS createdAt
+        FROM admin_action_log l
+        INNER JOIN members m ON m.member_id = l.admin_id
+        ORDER BY l.created_at DESC, l.admin_action_log_id DESC
+        LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
+</mapper>

--- a/src/main/resources/sql/2026-05-17_add_admin_action_log.sql
+++ b/src/main/resources/sql/2026-05-17_add_admin_action_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE admin_action_log (
+    admin_action_log_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    admin_id BIGINT NOT NULL,
+    action_type ENUM('MEMBER_BANNED','MEMBER_UNBANNED','REPORT_RESOLVED') NOT NULL,
+    target_type ENUM('MEMBER','REPORT') NOT NULL,
+    target_id BIGINT NOT NULL,
+    action_detail VARCHAR(500),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (admin_id) REFERENCES members(member_id)
+);

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -101,6 +101,18 @@ CREATE TABLE report (
     FOREIGN KEY (processed_by) REFERENCES members(member_id)
 );
 
+CREATE TABLE admin_action_log (
+    admin_action_log_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    admin_id BIGINT NOT NULL,
+    action_type ENUM('MEMBER_BANNED','MEMBER_UNBANNED','REPORT_RESOLVED') NOT NULL,
+    target_type ENUM('MEMBER','REPORT') NOT NULL,
+    target_id BIGINT NOT NULL,
+    action_detail VARCHAR(500),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (admin_id) REFERENCES members(member_id)
+);
+
 CREATE TABLE chat_rooms (
     chat_room_id BIGINT PRIMARY KEY AUTO_INCREMENT,
     room_id BIGINT NOT NULL,

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -187,6 +187,34 @@ body {
   font-weight: 700;
 }
 
+.report-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.report-filter-btn {
+  min-width: 64px;
+  height: 36px;
+  border: 1px solid #d0d5dd;
+  border-radius: 6px;
+  background: #fff;
+  color: #344054;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.report-filter-btn:hover {
+  background: #f9fafb;
+}
+
+.report-filter-btn.is-active {
+  border-color: #98a2b3;
+  background: #f2f4f7;
+  color: #101828;
+}
+
 .member-role,
 .member-status,
 .report-status {

--- a/src/main/webapp/resources/js/admin/reportList.js
+++ b/src/main/webapp/resources/js/admin/reportList.js
@@ -7,13 +7,12 @@ let totalPages = 1;
 let currentFilters = {};
 let selectedReportId = null;
 let pageSize = 20;
-let currentPage = 1;
-let totalPages = 0;
 
 document.addEventListener("DOMContentLoaded", async () => {
   bindPageSizeSelect();
+  bindSearchForm();
   bindFilterButtons();
-  bindPaginationButtons();
+  bindPagination();
   bindResolutionModal();
   await loadReports();
 });
@@ -24,7 +23,12 @@ async function loadReports(page = currentPage) {
   if (!count || !tableBody) return;
 
   try {
-    const response = await apiRequest(`${contextPath}/api/admin/reports?page=${currentPage}&size=${pageSize}`, {
+    const params = new URLSearchParams({
+      page: String(page),
+      size: String(pageSize),
+      ...currentFilters,
+    });
+    const response = await apiRequest(`${contextPath}/api/admin/reports?${params.toString()}`, {
       method: "GET",
     });
 
@@ -34,10 +38,9 @@ async function loadReports(page = currentPage) {
 
     const data = await response.json();
     reports = Array.isArray(data.items) ? data.items : [];
-    currentPage = Number(data.page || currentPage);
+    currentPage = Number(data.page || 1);
     totalPages = Number(data.total_pages || 0);
     count.textContent = `전체 신고 ${formatNumber(data.total_count || 0)}건`;
-    renderPagination();
     renderReports();
     renderPagination();
   } catch (error) {
@@ -62,32 +65,57 @@ function bindPageSizeSelect() {
   });
 }
 
+function bindSearchForm() {
+  const form = document.getElementById("reportSearchForm");
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    currentFilters = Object.fromEntries(
+      [...formData.entries()]
+        .map(([key, value]) => [key, String(value).trim()])
+        .filter(([, value]) => value)
+    );
+    syncFilterButtons(currentFilters.status || "");
+    currentPage = 1;
+    await loadReports(1);
+  });
+}
+
 function bindFilterButtons() {
   document.querySelectorAll(".report-filter-btn").forEach((button) => {
-    button.addEventListener("click", () => {
-      activeStatus = button.dataset.status || "ALL";
-      document.querySelectorAll(".report-filter-btn").forEach((item) => {
-        item.classList.toggle("is-active", item === button);
-      });
-      renderReports();
+    button.addEventListener("click", async () => {
+      const status = button.dataset.status === "ALL" ? "" : (button.dataset.status || "");
+      const statusSelect = document.querySelector('#reportSearchForm select[name="status"]');
+      if (statusSelect) {
+        statusSelect.value = status;
+      }
+      currentFilters = {
+        ...currentFilters,
+        ...(status ? { status } : {}),
+      };
+      if (!status) {
+        delete currentFilters.status;
+      }
+      syncFilterButtons(status);
+      currentPage = 1;
+      await loadReports(1);
     });
   });
 }
 
-function bindPaginationButtons() {
-  const prevButton = document.getElementById("btnPrevReports");
-  const nextButton = document.getElementById("btnNextReports");
-
-  prevButton?.addEventListener("click", async () => {
-    if (currentPage <= 1) return;
-    currentPage -= 1;
-    await loadReports();
+function syncFilterButtons(status) {
+  document.querySelectorAll(".report-filter-btn").forEach((button) => {
+    const buttonStatus = button.dataset.status === "ALL" ? "" : (button.dataset.status || "");
+    button.classList.toggle("is-active", buttonStatus === status);
   });
+}
 
-  nextButton?.addEventListener("click", async () => {
-    if (currentPage >= totalPages) return;
-    currentPage += 1;
-    await loadReports();
+function bindPagination() {
+  document.getElementById("btnPrevReports")?.addEventListener("click", async () => {
+    if (currentPage > 1) await loadReports(currentPage - 1);
+  });
+  document.getElementById("btnNextReports")?.addEventListener("click", async () => {
+    if (currentPage < totalPages) await loadReports(currentPage + 1);
   });
 }
 
@@ -129,9 +157,10 @@ function renderPagination() {
   const pageInfo = document.getElementById("reportPageInfo");
   if (!prevButton || !nextButton || !pageInfo) return;
 
-  prevButton.disabled = currentPage <= 1 || totalPages === 0;
-  nextButton.disabled = currentPage >= totalPages || totalPages === 0;
-  pageInfo.textContent = totalPages === 0 ? "0 / 0" : `${currentPage} / ${totalPages}`;
+  const safeTotalPages = totalPages || 1;
+  prevButton.disabled = currentPage <= 1;
+  nextButton.disabled = totalPages === 0 || currentPage >= totalPages;
+  pageInfo.textContent = `${currentPage} / ${safeTotalPages}`;
 }
 
 function renderReportRow(report) {


### PR DESCRIPTION
  ## 작업 내용                                                                                                        
  - 관리자 작업 로그 테이블을 추가했습니다.                                                                           
  - 회원 정지/해제 작업 시 관리자 작업 로그가 저장되도록 했습니다.                                                    
  - 신고 처리 작업 시 관리자 작업 로그가 저장되도록 했습니다.                                                         
  - 관리자 작업 로그 조회 API를 추가했습니다.                                                                         
  - 최신 develop 반영 과정에서 누락된 신고 목록 렌더링 문제를 함께 수정했습니다.                                      
  - 신고 상태 필터 버튼 스타일을 페이지네이션 버튼과 같은 톤으로 정리했습니다.                                        
                                                                                                                      
  ## 확인 사항                                                                                                        
  - 회원 정지 시 `MEMBER_BANNED` 로그가 저장됩니다.                                                                   
  - 회원 해제 시 `MEMBER_UNBANNED` 로그가 저장됩니다.                                                                 
  - 신고 처리 시 `REPORT_RESOLVED` 로그가 저장됩니다.                                                                 
  - 작업 로그에는 수행 관리자, 작업 종류, 대상 종류, 대상 ID, 수행 시각이 포함됩니다.                                 
  - 관리자만 작업 로그 API를 조회할 수 있습니다.                                                                      
  - 신고 관리 목록이 정상적으로 렌더링됩니다.                                                                         
                                                                                                                      
  ## API                                                                                                              
  - `GET /api/admin/action-logs`                                                                                      
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - 회원 정지/해제 후 작업 로그 저장 확인                                                                             
  - 신고 처리 후 작업 로그 저장 확인                                                                                  
  - 관리자 작업 로그 조회 API 응답 확인                                                                               
  - 신고 관리 목록 API 응답 및 화면 렌더링 확인                                                                       
                                                                                                                      
  closes #66 