### PR TITLE
feat: 관리자 신고 처리 상세 입력 UI 보완

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/main.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/main.jsp
@@ -214,6 +214,21 @@
       </div>
 
       <form id="reportResolutionForm" class="report-resolution-form">
+        <div class="report-resolution-summary" id="reportResolutionSummary">
+          <div>
+            <span>신고 대상</span>
+            <strong id="resolutionTarget">-</strong>
+          </div>
+          <div>
+            <span>신고자</span>
+            <strong id="resolutionReporter">-</strong>
+          </div>
+          <div class="report-resolution-reason">
+            <span>신고 사유</span>
+            <strong id="resolutionReason">-</strong>
+          </div>
+        </div>
+
         <label>
           <span>처리 결과</span>
           <select name="resolution_type" required>

--- a/src/main/webapp/resources/css/admin/main.css
+++ b/src/main/webapp/resources/css/admin/main.css
@@ -482,6 +482,36 @@ body {
   margin-top: 22px;
 }
 
+.report-resolution-summary {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #eaecf0;
+  border-radius: 6px;
+  background: #f9fafb;
+}
+
+.report-resolution-summary div {
+  display: grid;
+  gap: 4px;
+}
+
+.report-resolution-summary span {
+  color: #475467;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.report-resolution-summary strong {
+  color: #101828;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.report-resolution-reason strong {
+  white-space: pre-wrap;
+}
+
 .report-resolution-form label {
   display: grid;
   gap: 8px;

--- a/src/main/webapp/resources/js/admin/reportList.js
+++ b/src/main/webapp/resources/js/admin/reportList.js
@@ -214,8 +214,10 @@ function openResolutionModal(reportId) {
   const form = document.getElementById("reportResolutionForm");
   if (!modal || !form || !reportId) return;
 
+  const report = reports.find((item) => String(item.report_id) === String(reportId));
   selectedReportId = reportId;
   form.reset();
+  renderResolutionSummary(report);
   modal.classList.add("is-open");
   modal.setAttribute("aria-hidden", "false");
 }
@@ -227,8 +229,29 @@ function closeResolutionModal() {
 
   selectedReportId = null;
   form.reset();
+  renderResolutionSummary(null);
   modal.classList.remove("is-open");
   modal.setAttribute("aria-hidden", "true");
+}
+
+function renderResolutionSummary(report) {
+  setSummaryText("resolutionTarget", report ? formatParty(report.target_member_name, report.target_member_email) : "-");
+  setSummaryText("resolutionReporter", report ? formatParty(report.reporter_name, report.reporter_email) : "-");
+  setSummaryText("resolutionReason", report?.reason || "-");
+}
+
+function setSummaryText(id, value) {
+  const element = document.getElementById(id);
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function formatParty(name, email) {
+  if (!name && !email) return "-";
+  if (!name) return email || "-";
+  if (!email) return name;
+  return `${name} (${email})`;
 }
 
 async function submitResolution(form) {


### PR DESCRIPTION
 ## 작업 내용                                                                                                        
  - 신고 처리 모달에 현재 처리 중인 신고 요약 영역을 추가했습니다.                                                    
  - 신고 대상, 신고자, 신고 사유를 모달 안에서 바로 확인할 수 있게 했습니다.                                          
  - 기존 처리 결과 입력 UI는 유지하면서, 처리 맥락 확인성을 높였습니다.                                               
                                                                                                                      
  ## 확인 사항
  - 관리자는 신고 처리 전에 신고 대상과 신고자를 확인할 수 있습니다.                                                  
  - 관리자는 신고 사유를 모달에서 바로 확인할 수 있습니다.                                                            
  - 기존 처리 결과 선택과 안내 문구 입력 흐름은 유지됩니다.                                                           
                                                                                                                      
  ## 테스트                                                                                                           
  - `mvn -q -DskipTests compile`                                                                                      
  - `/admin` 신고 목록에서 처리 모달 열기 확인
  - 모달 내 신고 대상/신고자/사유 표시 확인                                                                           
                                                                                                                      
  closes #72  